### PR TITLE
Planned OpenAPI Spec

### DIFF
--- a/docs/open-api-planned-spec.yml
+++ b/docs/open-api-planned-spec.yml
@@ -1653,7 +1653,8 @@
         "title": "Root Type for AssignationRequest",
         "description": "",
         "required": [
-          "type"
+          "type",
+          "assignee"
         ],
         "type": "object",
         "properties": {


### PR DESCRIPTION
Adds all endpoints' OpenAPI Specification that UserTasks API need to have in order to offer an end-to-end experience for both types of users (standard and administrator).

Take into account that the `open-api-planned-spec.yml` file is a living file that will probably change in the future when the team finds some new features that need to be added into UserTasks API.