### PR TITLE
feat: Implements proper tenant-oidc config validation in TenantService

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ on http://localhost:8888
   to navigate to the **Settings** tab, scroll down until you reach the **Capability config** section, now disable the
   _**Client authentication**_ property (unless you want to use Service Account roles) and keep default values for all
   the other fields
+- Within the **Clients** section, click on your client id to see the details. Once you are seeing your client's details
+  navigate to the _Client Scopes_ tab and click on your client's scope. Once you have clicked on your client's scope,
+  you
+  will now see the mappers, and there you need to create one custom claim. To do that, click on _**Add mapper**_, and
+  select
+  _By configuration_. Now, from the list of mappings, choose **Hardcoded claim**. In the mapper details form you have to
+  set
+  **_allowed_tenant_** as the value in both fields _Name_ and _Token Claim Name_, and your tenant id MUST be the value
+  of
+  _Claim value_ field, keep the _Claim JSON Type_ as String and make sure that you switch on the _Add to access token_
+  property
 - Go to the **Users** section on the left sidebar, now you can create a user with username as `my-user`
   (email and names are optional, so, feel free to fill them up or ignore them)
 - Go to the **Credentials** tab in **Users** section and add a password as `1234` (Make sure that you uncheck
@@ -146,13 +157,15 @@ Here's what you need to modify in that file:
 - _**iss**_: Here you need to paste your Identity Provider's issuer url.
 - _**username-claim**_: This field is currently not being used, but it is part of the required configuration,
   so you can just leave it as is with the default value as _preferred_username_
-- _**authorities**_: Within this property you need to set at least 1 JSON path that indicates from where the roles are
+- _**authorities**_: Within this property you MUST set at least 1 JSON path that indicates from where the roles are
   going to be found within the token's claims, and this is important to help the API differentiate between ADMIN
   and NON-ADMIN users.
 - _**vendor**_: This indicates who is the vendor or identity provider in charge of the authentication of users for
   the previously set issuer. For now, Keycloak is the only vendor with access to all the features that this API
   provides.
-  _More vendors are going to be supported in the future._
+- **tenant-id**: This property must match your Tenant that MUST be already created within LittleHorse Server.
+- **clients**: Within this property you MUST set at least one client-id from your Keycloak realm from which your
+  access tokens will be generated.
 
 When you have your oidc-properties.yml properly configured, you will be ready to run UserTasks API from the source code.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   user-tasks-keycloak:
     ports:
       - "8888:8888"
-    image: quay.io/keycloak/keycloak:21.1.1
+    image: quay.io/keycloak/keycloak:25.0.1
     healthcheck:
       test: "timeout 5s bash -c ':> /dev/tcp/localhost/8888'"
       timeout: 5s

--- a/src/main/java/io/littlehorse/usertasks/configurations/CustomIdentityProviderProperties.java
+++ b/src/main/java/io/littlehorse/usertasks/configurations/CustomIdentityProviderProperties.java
@@ -6,10 +6,13 @@ import lombok.Data;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.net.URI;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
 
 @Data
 @AllArgsConstructor
@@ -17,14 +20,24 @@ public class CustomIdentityProviderProperties {
     private URI iss;
     private String usernameClaim;
     private IdentityProviderVendor vendor;
+    private String tenantId;
+    private Set<String> clients;
 
     public static CustomIdentityProviderProperties getCustomIdentityProviderProperties(@NonNull String issuerUrl,
+                                                                                       @NonNull String tenantId,
+                                                                                       @NonNull String clientId,
                                                                                        @NonNull IdentityProviderConfigProperties identityProviderConfigProperties) {
         Optional<CustomIdentityProviderProperties> actualProperties = identityProviderConfigProperties.getOps().stream()
-                .filter(customProperties ->
-                        StringUtils.equalsIgnoreCase(customProperties.getIss().toString(), issuerUrl))
+                .filter(matchingConfigurations(issuerUrl, tenantId, clientId))
                 .findFirst();
 
         return actualProperties.orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+    }
+
+    private static Predicate<CustomIdentityProviderProperties> matchingConfigurations(String issuerUrl, String tenantId,
+                                                                                      String clientId) {
+        return customProperties -> StringUtils.equalsIgnoreCase(customProperties.getIss().toString(), issuerUrl)
+                && StringUtils.equalsIgnoreCase(customProperties.getTenantId(), tenantId)
+                && !CollectionUtils.isEmpty(customProperties.getClients()) && customProperties.getClients().contains(clientId);
     }
 }

--- a/src/main/java/io/littlehorse/usertasks/controllers/InitController.java
+++ b/src/main/java/io/littlehorse/usertasks/controllers/InitController.java
@@ -51,7 +51,7 @@ public class InitController {
     @GetMapping("/{tenant_id}/init")
     public void initIntegrationForTenant(@RequestHeader("Authorization") String accessToken,
                                          @PathVariable(name = "tenant_id") String tenantId) {
-        if (!tenantService.isValidTenant(tenantId)) {
+        if (!tenantService.isValidTenant(tenantId, accessToken)) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }
 

--- a/src/main/java/io/littlehorse/usertasks/services/TenantService.java
+++ b/src/main/java/io/littlehorse/usertasks/services/TenantService.java
@@ -1,46 +1,75 @@
 package io.littlehorse.usertasks.services;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.littlehorse.sdk.common.proto.LittleHorseGrpc;
 import io.littlehorse.sdk.common.proto.Tenant;
 import io.littlehorse.sdk.common.proto.TenantId;
+import io.littlehorse.usertasks.configurations.IdentityProviderConfigProperties;
+import io.littlehorse.usertasks.util.TokenUtil;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Map;
 import java.util.Objects;
+
+import static io.littlehorse.usertasks.configurations.CustomIdentityProviderProperties.getCustomIdentityProviderProperties;
+import static io.littlehorse.usertasks.util.constants.TokenClaimConstants.ALLOWED_TOKEN_CUSTOM_CLAIM;
+import static io.littlehorse.usertasks.util.constants.TokenClaimConstants.AUTHORIZED_PARTY_CLAIM;
+import static io.littlehorse.usertasks.util.constants.TokenClaimConstants.ISSUER_URL_CLAIM;
 
 @Service
 @Slf4j
 public class TenantService {
     private final LittleHorseGrpc.LittleHorseBlockingStub lhClient;
+    private final IdentityProviderConfigProperties identityProviderConfigProperties;
 
-    TenantService(LittleHorseGrpc.LittleHorseBlockingStub lhClient) {
+    TenantService(LittleHorseGrpc.LittleHorseBlockingStub lhClient, IdentityProviderConfigProperties identityProviderConfigProperties) {
         this.lhClient = lhClient;
+        this.identityProviderConfigProperties = identityProviderConfigProperties;
     }
 
-    //TODO: The way we ware verifying if a tenant is valid will probably change once we set production-ready OIDC configuration per tenant
-    public boolean isValidTenant(@NonNull String tenantId) {
-        Tenant tenant = null;
+    public boolean isValidTenant(@NonNull String requestTenantId, @NonNull String accessToken) {
         try {
-            tenant = lhClient.getTenant(TenantId.newBuilder()
-                    .setId(tenantId)
+            Tenant tenant = lhClient.getTenant(TenantId.newBuilder()
+                    .setId(requestTenantId)
                     .build());
+
+            return Objects.nonNull(tenant) && isMatchingPropertiesConfiguration(requestTenantId, accessToken);
         } catch (StatusRuntimeException e) {
             if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
                 log.atInfo()
                         .setMessage("Tenant {} was not found in LH Server!")
-                        .addArgument(tenantId)
+                        .addArgument(requestTenantId)
                         .log();
             } else {
                 throw e;
             }
+        } catch (JsonProcessingException e) {
+            log.error("Something went wrong getting claims from token while matching properties configuration.", e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
-            log.error("Something went wrong while getting Tenant from LH Server.", e);
+            log.error("Something went wrong while validating Tenant.", e);
             throw e;
         }
 
-        return Objects.nonNull(tenant);
+        return false;
+    }
+
+    private boolean isMatchingPropertiesConfiguration(String requestTenantId, String accessToken) throws JsonProcessingException {
+        Map<String, Object> tokenClaims = TokenUtil.getTokenClaims(accessToken);
+        var issuerUrl = (String) tokenClaims.get(ISSUER_URL_CLAIM);
+        var tokenTenantId = (String) tokenClaims.get(ALLOWED_TOKEN_CUSTOM_CLAIM);
+        var client = (String) tokenClaims.get(AUTHORIZED_PARTY_CLAIM);
+
+        //Here we make sure that valid configuration properties actually exist
+        getCustomIdentityProviderProperties(issuerUrl, tokenTenantId, client, identityProviderConfigProperties);
+
+        return StringUtils.equalsIgnoreCase(requestTenantId, tokenTenantId);
     }
 }

--- a/src/main/java/io/littlehorse/usertasks/util/constants/TokenClaimConstants.java
+++ b/src/main/java/io/littlehorse/usertasks/util/constants/TokenClaimConstants.java
@@ -3,4 +3,6 @@ package io.littlehorse.usertasks.util.constants;
 public class TokenClaimConstants {
     public static final String USER_ID_CLAIM = "sub";
     public static final String ISSUER_URL_CLAIM = "iss";
+    public static final String ALLOWED_TOKEN_CUSTOM_CLAIM = "allowed_tenant";
+    public static final String AUTHORIZED_PARTY_CLAIM = "azp";
 }

--- a/src/test/java/io/littlehorse/usertasks/services/TenantServiceTest.java
+++ b/src/test/java/io/littlehorse/usertasks/services/TenantServiceTest.java
@@ -1,21 +1,37 @@
 package io.littlehorse.usertasks.services;
 
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.littlehorse.sdk.common.proto.LittleHorseGrpc;
 import io.littlehorse.sdk.common.proto.Tenant;
 import io.littlehorse.sdk.common.proto.TenantId;
-import io.littlehorse.usertasks.exceptions.NotFoundException;
+import io.littlehorse.usertasks.configurations.CustomIdentityProviderProperties;
+import io.littlehorse.usertasks.configurations.IdentityProviderConfigProperties;
+import io.littlehorse.usertasks.idp_adapters.IdentityProviderVendor;
+import io.littlehorse.usertasks.util.TokenUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -23,57 +39,85 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class TenantServiceTest {
     private final LittleHorseGrpc.LittleHorseBlockingStub lhClient = mock();
+    private final IdentityProviderConfigProperties identityProviderConfigProperties = mock();
 
-    private final TenantService tenantService = new TenantService(lhClient);
+    private final TenantService tenantService = new TenantService(lhClient, identityProviderConfigProperties);
+
+    private final String STUBBED_ACCESS_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJIbkdSc3I1eGpub1UyN0k" +
+            "ycVBSMUYwMHEzNlRSaW9iQ3RESU5ET1NFNnNNIn0.eyJleHAiOjE3MjU5MjA0OTAsImlhdCI6MTcyNTkyMDE5MCwianRpIjoiNGY4MzEwZW" +
+            "ItNjIyYy00ZDU3LWEzYzYtZDA2MzM0Zjc5ZjI2IiwiaXNzIjoiaHR0cDovL3VzZXItdGFza3Mta2V5Y2xvYWs6ODg4OC9yZWFsbXMvbGgiL" +
+            "CJhdWQiOlsicmVhbG0tbWFuYWdlbWVudCIsImFjY291bnQiXSwic3ViIjoiMjdhOGNhNTAtNGFkZi00MjE4LTgwNTQtMmI1ZTVlMDhhMGZh" +
+            "IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidXNlci10YXNrcy1jbGllbnQtMiIsInNpZCI6IjdjMDdkMGNmLTc5NWItNGVlNC1hODBlLTBhYzA" +
+            "0OGQ4MWFiMiIsImFjciI6IjEiLCJhbGxvd2VkLW9yaWdpbnMiOlsiLyoiXSwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbImxoLXVzZXItdG" +
+            "Fza3MtYWRtaW4iLCJvZmZsaW5lX2FjY2VzcyIsImRlZmF1bHQtcm9sZXMtbGgiLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfY" +
+            "WNjZXNzIjp7InJlYWxtLW1hbmFnZW1lbnQiOnsicm9sZXMiOlsidmlldy11c2VycyIsInF1ZXJ5LWdyb3VwcyIsInF1ZXJ5LXVzZXJzIl19" +
+            "LCJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJ" +
+            "zY29wZSI6Im9wZW5pZCBwcm9maWxlIGVtYWlsIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsIm5hbWUiOiJMaCBBZG1pbiBVc2VyIiwiYWxsb3" +
+            "dlZF90ZW5hbnQiOiJteS1sb2NhbC10ZW5hbnQiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJsaC1hZG1pbi11c2VyIiwiZ2l2ZW5fbmFtZSI6I" +
+            "kxoIiwiZmFtaWx5X25hbWUiOiJBZG1pbiBVc2VyIiwiZW1haWwiOiJsaGFkbWludXNlckBzb21lZG9tYWluLmNvbSJ9.FT1Ov-KB7PbZNJz" +
+            "3wBEfu7pshDV6_bGClyH7Vz-maeH5YGL8nBrViIKLXEK_ZrPLwn4vmgOPdblm2F0QBdhCzyTh4C8q36OnOa1AQGhMbP0r7uNPJ4NS-THsD8" +
+            "I7n-SUzXtw6cJYTeeZHLgfTdYIH3k1sGxw6bpTkk0_lkvba9tmjCD4PwxsQvaoKcz1-32JSMsAe2Cx7MktXXljp1c-G7MnSr4Ina1-3iV0C" +
+            "z022L-8Mr3WMLhplRnXOQN3UcE1QWHIAoxyJV8-uc5Ob8-RIL3qG0v60J52l5SZj6dheNtCpObUYrYMfs3abCa5o7SNpPjOuuJ8Qqbe5Yvl" +
+            "OsX_bA";
 
     @Test
-    void isValidTenant_shouldThrowNullPointerExceptionWhenTenantIdIsNull() throws NotFoundException {
-        assertThrows(NullPointerException.class, () -> tenantService.isValidTenant(null));
+    void isValidTenant_shouldThrowNullPointerExceptionWhenTenantIdIsNull() {
+        assertThrows(NullPointerException.class, () -> tenantService.isValidTenant(null, STUBBED_ACCESS_TOKEN));
 
         verify(lhClient, never()).getTenant(any(TenantId.class));
     }
 
     @Test
-    void isValidTenant_shouldReturnFalseWhenNoMatchingTenantIsFound() throws NotFoundException {
+    void isValidTenant_shouldThrowNullPointerExceptionWhenAccessTokenIsNull() {
+        var tenantIdToValidate = "someTenantId";
+        assertThrows(NullPointerException.class, () -> tenantService.isValidTenant(tenantIdToValidate, null));
+
+        verify(lhClient, never()).getTenant(any(TenantId.class));
+    }
+
+    @Test
+    void isValidTenant_shouldReturnFalseWhenNoMatchingTenantIsFound() {
         var tenantIdToValidate = "invalidTenantId";
 
         when(lhClient.getTenant(any(TenantId.class))).thenReturn(null);
 
-        assertFalse(tenantService.isValidTenant(tenantIdToValidate));
+        assertFalse(tenantService.isValidTenant(tenantIdToValidate, STUBBED_ACCESS_TOKEN));
 
         verify(lhClient).getTenant(any(TenantId.class));
     }
 
     @Test
-    void isValidTenant_shouldReturnFalseWhenServerAPIThrowsNotFoundException() throws NotFoundException {
+    void isValidTenant_shouldReturnFalseWhenServerAPIThrowsNotFoundException() {
         var tenantIdToValidate = "someTenant";
 
         when(lhClient.getTenant(any(TenantId.class))).thenThrow(new StatusRuntimeException(Status.NOT_FOUND));
 
-        assertFalse(tenantService.isValidTenant(tenantIdToValidate));
+        assertFalse(tenantService.isValidTenant(tenantIdToValidate, STUBBED_ACCESS_TOKEN));
 
         verify(lhClient).getTenant(any(TenantId.class));
     }
 
     @Test
-    void isValidTenant_shouldReturnFalseWhenServerAPIThrowsUnhandledException() throws NotFoundException {
+    void isValidTenant_shouldReturnFalseWhenServerAPIThrowsUnhandledException() {
         var tenantIdToValidate = "someOtherTenant";
 
         when(lhClient.getTenant(any(TenantId.class))).thenThrow(new StatusRuntimeException(Status.ABORTED));
 
-        assertThrows(StatusRuntimeException.class, () -> tenantService.isValidTenant(tenantIdToValidate));
+        assertThrows(StatusRuntimeException.class,
+                () -> tenantService.isValidTenant(tenantIdToValidate, STUBBED_ACCESS_TOKEN));
 
         verify(lhClient).getTenant(any(TenantId.class));
     }
 
     @Test
-    void isValidTenant_shouldReturnFalseWhenServerAPIThrowsAnExceptionDifferentFromNotFoundException() throws NotFoundException {
+    void isValidTenant_shouldReturnFalseWhenServerAPIThrowsAnExceptionDifferentFromNotFoundException() {
         var tenantIdToValidate = "someTenant";
         var expectedExceptionMessage = "ERROR: Some pretty weird issue on LH Server";
 
         when(lhClient.getTenant(any(TenantId.class))).thenThrow(new RuntimeException(expectedExceptionMessage));
 
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> tenantService.isValidTenant(tenantIdToValidate));
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> tenantService.isValidTenant(tenantIdToValidate, STUBBED_ACCESS_TOKEN));
 
         assertEquals(expectedExceptionMessage, exception.getMessage());
 
@@ -81,12 +125,58 @@ class TenantServiceTest {
     }
 
     @Test
-    void isValidTenant_shouldReturnTrueWhenTenantIdIsPresentInLHServer() throws NotFoundException {
-        String tenantIdToValidate = "my-tenant-id";
+    void isValidTenant_shouldThrowResponseStatusExceptionAsInternalServerErrorWhenAnExceptionIsThrownWhileReadingClaimsFromToken() {
+        var tenantIdToValidate = "someTenant";
+
+        try (MockedStatic<TokenUtil> mockStaticTokenUtil = mockStatic(TokenUtil.class)) {
+            when(lhClient.getTenant(any(TenantId.class))).thenReturn(Tenant.getDefaultInstance());
+            mockStaticTokenUtil.when(() -> TokenUtil.getTokenClaims(anyString()))
+                    .thenThrow(new UnrecognizedPropertyException(mock(JsonParser.class), "error message",
+                            mock(JsonLocation.class), TokenUtil.class, "some-property", Collections.emptyList()));
+
+            ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                    () -> tenantService.isValidTenant(tenantIdToValidate, "wrongToken"));
+
+            int expectedHttpErrorCode = HttpStatus.INTERNAL_SERVER_ERROR.value();
+            assertEquals(expectedHttpErrorCode, exception.getBody().getStatus());
+
+            verify(lhClient).getTenant(any(TenantId.class));
+        }
+    }
+
+    @Test
+    void isValidTenant_shouldReturnTrueWhenTenantIdIsPresentInLHServerAndAlsoInConfigurationProperties() {
+        var tenantIdToValidate = "my-local-tenant";
+        URI fakeUri = URI.create("http://user-tasks-keycloak:8888/realms/lh");
+        var fakeUsernameClaim = "preferred_username";
+        IdentityProviderVendor fakeVendor = IdentityProviderVendor.KEYCLOAK;
+        Set<String> clients = Set.of("user-tasks-client-2");
+
+        var properties = new CustomIdentityProviderProperties(fakeUri, fakeUsernameClaim, fakeVendor, tenantIdToValidate, clients);
 
         when(lhClient.getTenant(any(TenantId.class))).thenReturn(Tenant.getDefaultInstance());
+        when(identityProviderConfigProperties.getOps()).thenReturn(List.of(properties));
 
-        assertTrue(tenantService.isValidTenant(tenantIdToValidate));
+        assertTrue(tenantService.isValidTenant(tenantIdToValidate, STUBBED_ACCESS_TOKEN));
+
+        verify(lhClient).getTenant(any(TenantId.class));
+    }
+
+    @Test
+    void isValidTenant_shouldReturnFalseWhenTenantIdIsPresentInLHServerButItIsNotPresentInConfigurationProperties() {
+        var configuredTenant = "my-local-tenant";
+        var tenantIdToValidate = "some-random-tenant";
+        URI fakeUri = URI.create("http://user-tasks-keycloak:8888/realms/lh");
+        var fakeUsernameClaim = "preferred_username";
+        IdentityProviderVendor fakeVendor = IdentityProviderVendor.KEYCLOAK;
+        Set<String> clients = Set.of("user-tasks-client-2");
+
+        var properties = new CustomIdentityProviderProperties(fakeUri, fakeUsernameClaim, fakeVendor, configuredTenant, clients);
+
+        when(lhClient.getTenant(any(TenantId.class))).thenReturn(Tenant.getDefaultInstance());
+        when(identityProviderConfigProperties.getOps()).thenReturn(List.of(properties));
+
+        assertFalse(tenantService.isValidTenant(tenantIdToValidate, STUBBED_ACCESS_TOKEN));
 
         verify(lhClient).getTenant(any(TenantId.class));
     }

--- a/ut-config/oidc-properties.yml
+++ b/ut-config/oidc-properties.yml
@@ -9,3 +9,16 @@ com:
               - path: $.realm_access.roles
               - path: $.resource_access.*.roles
             vendor: keycloak
+            tenant-id: my-local-tenant
+            clients:
+              - user-tasks-client
+              - user-tasks-client-2
+          - iss: http://user-tasks-keycloak:8888/realms/lh-2
+            username-claim: preferred_username
+            authorities:
+              - path: $.realm_access.roles
+              - path: $.resource_access.*.roles
+            vendor: keycloak
+            tenant-id: my-local-tenant-2
+            clients:
+              - user-tasks-client-lh-2


### PR DESCRIPTION
Adds tenantId and clients as new custom properties. These 2 were key to develop a more reliable tenant-oidc config validation solution.

Adds new constants to represent the newly introduced custom claim and azp claim.

Upgrades Keycloak's image version used in docker-compose.yaml.

Updates README.md with instructions to create mapper that adds allowed_tenant custom claim.

Adds and modifies respective unit tests.