### PR TITLE
docs(open-api-spec): Makes 'type' request param mandatory in /tasks Admin endpoint

### DIFF
--- a/src/main/java/io/littlehorse/usertasks/configurations/WebSecurityConfiguration.java
+++ b/src/main/java/io/littlehorse/usertasks/configurations/WebSecurityConfiguration.java
@@ -37,7 +37,7 @@ public class WebSecurityConfiguration {
             throws Exception {
         http.authorizeHttpRequests(
                         auth -> auth
-                                .requestMatchers(HttpMethod.GET, new String[]{"/api-docs/**", "/swagger-ui/**"})// This will be used when open-api spec is in place
+                                .requestMatchers(HttpMethod.GET, new String[]{"/api-docs/**", "/swagger-ui/**"})
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated())

--- a/src/main/java/io/littlehorse/usertasks/controllers/AdminController.java
+++ b/src/main/java/io/littlehorse/usertasks/controllers/AdminController.java
@@ -116,7 +116,7 @@ public class AdminController {
                                                          LocalDateTime latestStartDate,
                                                           @RequestParam(name = "status", required = false)
                                                          UserTaskStatus status,
-                                                          @RequestParam(name = "type", required = false)
+                                                          @RequestParam(name = "type")
                                                          String type,
                                                           @RequestParam(name = "limit")
                                                          Integer limit,

--- a/src/main/java/io/littlehorse/usertasks/models/responses/AuditEventDTO.java
+++ b/src/main/java/io/littlehorse/usertasks/models/responses/AuditEventDTO.java
@@ -1,5 +1,6 @@
 package io.littlehorse.usertasks.models.responses;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.littlehorse.sdk.common.proto.TaskRunId;
 import io.littlehorse.sdk.common.proto.UserTaskEvent;
 import io.littlehorse.usertasks.util.DateUtil;
@@ -24,6 +25,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class AuditEventDTO {
     @NotNull
+    @JsonFormat(pattern= "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime time;
     @NotNull
     @Schema(oneOf = {UserTaskExecutedEvent.class, UserTaskAssignedEvent.class, UserTaskCancelledEvent.class})

--- a/src/main/java/io/littlehorse/usertasks/models/responses/DetailedUserTaskRunDTO.java
+++ b/src/main/java/io/littlehorse/usertasks/models/responses/DetailedUserTaskRunDTO.java
@@ -1,5 +1,6 @@
 package io.littlehorse.usertasks.models.responses;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.littlehorse.sdk.common.proto.UserTaskDef;
 import io.littlehorse.sdk.common.proto.UserTaskRun;
@@ -51,6 +52,7 @@ public class DetailedUserTaskRunDTO {
     private UserTaskStatus status;
     private String notes;
     @NotNull
+    @JsonFormat(pattern= "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime scheduledTime;
     @NotNull
     private List<UserTaskFieldDTO> fields;

--- a/src/main/java/io/littlehorse/usertasks/models/responses/SimpleUserTaskRunDTO.java
+++ b/src/main/java/io/littlehorse/usertasks/models/responses/SimpleUserTaskRunDTO.java
@@ -1,5 +1,6 @@
 package io.littlehorse.usertasks.models.responses;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.littlehorse.sdk.common.proto.UserTaskRun;
 import io.littlehorse.usertasks.models.common.UserDTO;
 import io.littlehorse.usertasks.models.common.UserGroupDTO;
@@ -39,6 +40,7 @@ public class SimpleUserTaskRunDTO {
     private UserTaskStatus status;
     private String notes;
     @NotNull
+    @JsonFormat(pattern= "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime scheduledTime;
 
     public static SimpleUserTaskRunDTO fromUserTaskRun(@NonNull UserTaskRun userTaskRun) {

--- a/src/main/java/io/littlehorse/usertasks/util/DateUtil.java
+++ b/src/main/java/io/littlehorse/usertasks/util/DateUtil.java
@@ -17,7 +17,7 @@ public class DateUtil {
     }
 
     public static LocalDateTime timestampToLocalDateTime(@NonNull Timestamp date) {
-        return LocalDateTime.ofEpochSecond(date.getSeconds(), date.getNanos(), ZoneOffset.UTC);
+        return LocalDateTime.ofEpochSecond(date.getSeconds(), date.getNanos(), UTC_ZONE);
     }
 
     public static Timestamp localDateTimeToTimestamp(@NonNull LocalDateTime date) {


### PR DESCRIPTION
Corrects format used in timestamp attributes in respective DTOs used as part of the response body of some Http requests