### PR TITLE
feat: Makes clientId access token claim configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Here's what you need to modify in that file:
   the previously set issuer. For now, Keycloak is the only vendor with access to all the features that this API
   provides.
 - **tenant-id**: This property must match your Tenant that MUST be already created within LittleHorse Server.
+- **client-id-claim**: This property specifies what claim should be used to fetch the corresponding client id from the access token.
 - **clients**: Within this property you MUST set at least one client-id from your Keycloak realm from which your
   access tokens will be generated.
 

--- a/api/src/main/java/io/littlehorse/usertasks/services/TenantService.java
+++ b/api/src/main/java/io/littlehorse/usertasks/services/TenantService.java
@@ -20,8 +20,6 @@ import java.util.Objects;
 
 import static io.littlehorse.usertasks.configurations.CustomIdentityProviderProperties.getCustomIdentityProviderProperties;
 import static io.littlehorse.usertasks.util.constants.TokenClaimConstants.ALLOWED_TOKEN_CUSTOM_CLAIM;
-import static io.littlehorse.usertasks.util.constants.TokenClaimConstants.AUTHORIZED_PARTY_CLAIM;
-import static io.littlehorse.usertasks.util.constants.TokenClaimConstants.ISSUER_URL_CLAIM;
 
 @Service
 @Slf4j
@@ -63,12 +61,10 @@ public class TenantService {
 
     private boolean isMatchingPropertiesConfiguration(String requestTenantId, String accessToken) throws JsonProcessingException {
         Map<String, Object> tokenClaims = TokenUtil.getTokenClaims(accessToken);
-        var issuerUrl = (String) tokenClaims.get(ISSUER_URL_CLAIM);
         var tokenTenantId = (String) tokenClaims.get(ALLOWED_TOKEN_CUSTOM_CLAIM);
-        var client = (String) tokenClaims.get(AUTHORIZED_PARTY_CLAIM);
 
         //Here we make sure that valid configuration properties actually exist
-        getCustomIdentityProviderProperties(issuerUrl, tokenTenantId, client, identityProviderConfigProperties);
+        getCustomIdentityProviderProperties(accessToken, identityProviderConfigProperties);
 
         return StringUtils.equalsIgnoreCase(requestTenantId, tokenTenantId);
     }

--- a/standalone/api-properties.yml
+++ b/standalone/api-properties.yml
@@ -10,5 +10,6 @@ com:
               - path: $.resource_access.*.roles
             vendor: keycloak
             tenant-id: default
+            client-id-claim: azp
             clients:
               - user-tasks-client

--- a/ut-config/oidc-properties.yml
+++ b/ut-config/oidc-properties.yml
@@ -10,5 +10,6 @@ com:
               - path: $.resource_access.*.roles
             vendor: keycloak
             tenant-id: default
+            client-id-claim: azp
             clients:
               - user-tasks-client


### PR DESCRIPTION
- Adds property to oidc-properties.yml to set from which claim the service must read the clientId value. 
- Refactors how to get and validate CustomIdentityProviderProperties. 
- Removes no longer required code.
- Adds and modifies respective unit tests.

This PR closes #75 