### PR TITLE
feat: Adds public endpoint to expose IdPs configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Make sure that you edit the `oidc-properties.yml` file located at `./config/` di
 Here's what you need to modify in that file:
 
 - _**iss**_: Here you need to paste your Identity Provider's issuer url.
+- _**label-name**_: This field allows you to set a string that can be used in your UI to differentiate your
+identity providers configured with the same tenant.
 - _**username-claim**_: This field is currently not being used, but it is part of the required configuration,
   so you can just leave it as is with the default value as _preferred_username_
 - _**authorities**_: Within this property you MUST set at least 1 JSON path that indicates from where the roles are

--- a/backend/src/main/java/io/littlehorse/usertasks/configurations/CustomIdentityProviderProperties.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/configurations/CustomIdentityProviderProperties.java
@@ -1,5 +1,6 @@
 package io.littlehorse.usertasks.configurations;
 
+import com.c4_soft.springaddons.security.oidc.starter.properties.SpringAddonsOidcProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.littlehorse.usertasks.idp_adapters.IdentityProviderVendor;
 import io.littlehorse.usertasks.util.TokenUtil;
@@ -12,6 +13,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -25,9 +27,11 @@ public class CustomIdentityProviderProperties {
     private URI iss;
     private String usernameClaim;
     private IdentityProviderVendor vendor;
+    private String labelName;
     private String tenantId;
     private Set<String> clients;
     private String clientIdClaim;
+    private List<SpringAddonsOidcProperties.OpenidProviderProperties.SimpleAuthoritiesMappingProperties> authorities;
 
     public static CustomIdentityProviderProperties getCustomIdentityProviderProperties(@NonNull String accessToken,
                                                                                        @NonNull IdentityProviderConfigProperties identityProviderConfigProperties) throws JsonProcessingException {

--- a/backend/src/main/java/io/littlehorse/usertasks/configurations/WebSecurityConfiguration.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/configurations/WebSecurityConfiguration.java
@@ -37,9 +37,11 @@ public class WebSecurityConfiguration {
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationManagerResolver<HttpServletRequest> authenticationManagerResolver)
             throws Exception {
+        String[] publicPaths = {"/config/**", "/api-docs/**", "/swagger-ui/**", "/actuator/**"}; //These paths do not require authentication
+
         http.authorizeHttpRequests(
                         auth -> auth
-                                .requestMatchers(HttpMethod.GET, new String[]{"/api-docs/**", "/swagger-ui/**", "/actuator/**"})
+                                .requestMatchers(HttpMethod.GET, publicPaths)
                                 .permitAll()
                                 .anyRequest()
                                 .authenticated())
@@ -74,7 +76,7 @@ public class WebSecurityConfiguration {
     }
 
     @Bean
-    public Map<String, LittleHorseGrpc.LittleHorseBlockingStub> lhClient(IdentityProviderConfigProperties identityProviderConfigProperties) throws NoSuchFieldException {
+    public Map<String, LittleHorseGrpc.LittleHorseBlockingStub> lhClient(IdentityProviderConfigProperties identityProviderConfigProperties) {
         Set<String> configuredTenants = getConfiguredTenants(identityProviderConfigProperties);
 
         if (CollectionUtils.isEmpty(configuredTenants)) {

--- a/backend/src/main/java/io/littlehorse/usertasks/controllers/PublicController.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/controllers/PublicController.java
@@ -1,0 +1,68 @@
+package io.littlehorse.usertasks.controllers;
+
+import io.littlehorse.usertasks.models.responses.IdentityProviderListDTO;
+import io.littlehorse.usertasks.services.TenantService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "Public Controller",
+        description = "This is a controller that exposes an endpoint that does not require any authentication nor authorization"
+)
+@RestController
+@CrossOrigin
+@Slf4j
+public class PublicController {
+    private final TenantService tenantService;
+
+    public PublicController(TenantService tenantService) {
+        this.tenantService = tenantService;
+    }
+
+    @Operation(
+            summary = "Get Configured IdP(s)",
+            description = "Gets the public configuration of the IdP(s) used by a specific tenant"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "List of unique Identity Provider Configurations",
+                    content = {@Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = IdentityProviderListDTO.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "No configuration data was found for the given tenant.",
+                    content = {@Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProblemDetail.class))}
+            )
+    })
+    @GetMapping("/config/{tenant_id}")
+    public ResponseEntity<IdentityProviderListDTO> getIdentityProviderConfig(@PathVariable(name = "tenant_id") String tenantId) {
+        log.atInfo()
+                .setMessage("Fetching IdP configurations for tenant: {}")
+                .addArgument(tenantId)
+                .log();
+
+        IdentityProviderListDTO idpConfigs = tenantService.getTenantIdentityProviderConfig(tenantId);
+
+        return !CollectionUtils.isEmpty(idpConfigs.getProviders())
+                ? ResponseEntity.ok(idpConfigs)
+                : ResponseEntity.of(ProblemDetail.forStatus(HttpStatus.NOT_FOUND.value())).build();
+    }
+}

--- a/backend/src/main/java/io/littlehorse/usertasks/models/responses/IdentityProviderDTO.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/models/responses/IdentityProviderDTO.java
@@ -1,0 +1,52 @@
+package io.littlehorse.usertasks.models.responses;
+
+import com.c4_soft.springaddons.security.oidc.starter.properties.SpringAddonsOidcProperties;
+import io.littlehorse.usertasks.configurations.CustomIdentityProviderProperties;
+import io.littlehorse.usertasks.idp_adapters.IdentityProviderVendor;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Builder
+@AllArgsConstructor
+@Data
+public class IdentityProviderDTO {
+    @NotNull
+    private IdentityProviderVendor vendor;
+    @NotNull
+    private String labelName;
+    @NotNull
+    private String issuer;
+    @NotNull
+    private String clientId;
+    @NotEmpty
+    private Set<String> authorities;
+
+    public static Set<IdentityProviderDTO> fromConfigProperties(CustomIdentityProviderProperties configProperties) {
+        Set<String> authorities = mapAuthorities(configProperties);
+        Set<IdentityProviderDTO> providers = new HashSet<>();
+
+        configProperties.getClients().forEach(clientId -> providers.add(IdentityProviderDTO.builder()
+                .labelName(configProperties.getLabelName())
+                .vendor(configProperties.getVendor())
+                .issuer(configProperties.getIss().toString())
+                .clientId(clientId)
+                .authorities(authorities)
+                .build()));
+
+        return Collections.unmodifiableSet(providers);
+    }
+
+    private static Set<String> mapAuthorities(CustomIdentityProviderProperties configProperties) {
+        return configProperties.getAuthorities().stream()
+                .map(SpringAddonsOidcProperties.OpenidProviderProperties.SimpleAuthoritiesMappingProperties::getPath)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/backend/src/main/java/io/littlehorse/usertasks/models/responses/IdentityProviderListDTO.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/models/responses/IdentityProviderListDTO.java
@@ -1,0 +1,14 @@
+package io.littlehorse.usertasks.models.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Set;
+
+@Builder
+@AllArgsConstructor
+@Data
+public class IdentityProviderListDTO {
+    private Set<IdentityProviderDTO> providers;
+}

--- a/backend/src/main/java/io/littlehorse/usertasks/services/TenantService.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/services/TenantService.java
@@ -7,6 +7,8 @@ import io.littlehorse.sdk.common.proto.LittleHorseGrpc;
 import io.littlehorse.sdk.common.proto.Tenant;
 import io.littlehorse.sdk.common.proto.TenantId;
 import io.littlehorse.usertasks.configurations.IdentityProviderConfigProperties;
+import io.littlehorse.usertasks.models.responses.IdentityProviderDTO;
+import io.littlehorse.usertasks.models.responses.IdentityProviderListDTO;
 import io.littlehorse.usertasks.util.TokenUtil;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +20,8 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static io.littlehorse.usertasks.configurations.CustomIdentityProviderProperties.getCustomIdentityProviderProperties;
 import static io.littlehorse.usertasks.util.constants.TokenClaimConstants.ALLOWED_TOKEN_CUSTOM_CLAIM;
@@ -59,6 +63,21 @@ public class TenantService {
         }
 
         return false;
+    }
+
+    @NonNull
+    public IdentityProviderListDTO getTenantIdentityProviderConfig(@NonNull String tenantId) {
+        Set<IdentityProviderDTO> tenantConfig = identityProviderConfigProperties.getOps().stream()
+                .filter(config ->
+                        StringUtils.equalsIgnoreCase(tenantId, config.getTenantId())
+                )
+                .map(IdentityProviderDTO::fromConfigProperties)
+                .flatMap(providerSet -> providerSet.stream().distinct())
+                .collect(Collectors.toSet());
+
+        return IdentityProviderListDTO.builder()
+                .providers(tenantConfig)
+                .build();
     }
 
     private LittleHorseGrpc.LittleHorseBlockingStub getTenantLHClient(String tenantId) {

--- a/config/oidc-properties.yml
+++ b/config/oidc-properties.yml
@@ -4,6 +4,7 @@ com:
       oidc:
         ops:
           - iss: http://keycloak:8888/realms/default
+            label-name: Default Keycloak
             username-claim: preferred_username
             authorities:
               - path: $.realm_access.roles

--- a/standalone/backend-properties.yml
+++ b/standalone/backend-properties.yml
@@ -4,6 +4,7 @@ com:
       oidc:
         ops:
           - iss: http://localhost:8888/realms/default
+            label-name: Default Keycloak
             username-claim: preferred_username
             authorities:
               - path: $.realm_access.roles


### PR DESCRIPTION
These changes take care of a feature request that came from a UTB Console requirement.

With this new endpoint the UTB Backend is now able to provide config data based on a tenantId, and that will allow the UTB console to determine which properties to use in order to show the respective login options to end users.