### PR TITLE
feat: Adds endpoint to fetch claimable UserTasks

### DIFF
--- a/backend/src/main/java/io/littlehorse/usertasks/configurations/OpenAPIConfiguration.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/configurations/OpenAPIConfiguration.java
@@ -12,7 +12,7 @@ public class OpenAPIConfiguration {
     @Bean
     public OpenAPI apiDocConfig() {
         return new OpenAPI().info(new Info()
-                        .title("UserTasks Bridge API")
+                        .title("UserTasks Bridge Backend")
                         .description("This is LittleHorse's custom API to handle UserTaskRuns existing in LittleHorse " +
                                 "Server and provide a seamless experience between LittleHorse Server and any OIDC-compliant " +
                                 "Identity Provider when working with LH UserTasks.")


### PR DESCRIPTION
These changes address an existing issue in the console where nonAdmin users cannot claim UserTasks assigned to the userGroups that they belong to.

Claimable UserTasks are those UserTasks which status is `UNASSIGNED` and userGroup is set to something other than `null` and whitespace string (`" "`).