### PR TITLE
feat(users-management): adds endpoint to fetch a managed user's data

### DIFF
--- a/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
@@ -2,6 +2,7 @@ package io.littlehorse.usertasks.idp_adapters;
 
 import io.littlehorse.usertasks.models.common.UserDTO;
 import io.littlehorse.usertasks.models.common.UserGroupDTO;
+import io.littlehorse.usertasks.models.responses.IDPUserDTO;
 import io.littlehorse.usertasks.models.responses.IDPUserListDTO;
 import io.littlehorse.usertasks.models.responses.UserGroupListDTO;
 import io.littlehorse.usertasks.models.responses.UserListDTO;
@@ -31,4 +32,6 @@ public interface IStandardIdentityProviderAdapter {
     void createUser(Map<String, Object> params);
 
     void setPassword(String userId, Map<String, Object> params);
+
+    IDPUserDTO getManagedUser(Map<String, Object> params);
 }

--- a/backend/src/main/java/io/littlehorse/usertasks/models/responses/IDPGroupDTO.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/models/responses/IDPGroupDTO.java
@@ -1,5 +1,6 @@
 package io.littlehorse.usertasks.models.responses;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Data;
 import org.keycloak.representations.idm.GroupRepresentation;
@@ -21,6 +22,7 @@ import java.util.stream.Collectors;
 public class IDPGroupDTO {
     private String id;
     private String name;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private Set<IDPUserDTO> members;
 
     /**

--- a/backend/src/main/java/io/littlehorse/usertasks/services/UserManagementService.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/services/UserManagementService.java
@@ -5,14 +5,17 @@ import io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter;
 import io.littlehorse.usertasks.models.requests.CreateManagedUserRequest;
 import io.littlehorse.usertasks.models.requests.IDPUserSearchRequestFilter;
 import io.littlehorse.usertasks.models.requests.PasswordUpsertRequest;
+import io.littlehorse.usertasks.models.responses.IDPUserDTO;
 import io.littlehorse.usertasks.models.responses.IDPUserListDTO;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter.ACCESS_TOKEN_MAP_KEY;
+import static io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter.USER_ID_MAP_KEY;
 
 @Service
 @Slf4j
@@ -48,5 +51,12 @@ public class UserManagementService {
                 "isTemporary", requestBody.isTemporary());
 
         identityProviderHandler.setPassword(userId, params);
+    }
+
+    public Optional<IDPUserDTO> getUserFromIdentityProvider(@NonNull String accessToken, @NonNull String userId,
+                                                           @NonNull IStandardIdentityProviderAdapter identityProviderHandler) {
+        Map<String, Object> params = Map.of(ACCESS_TOKEN_MAP_KEY, accessToken, USER_ID_MAP_KEY, userId);
+
+        return Optional.ofNullable(identityProviderHandler.getManagedUser(params));
     }
 }


### PR DESCRIPTION
Adds respective OpenAPI Spec docs.
Implements a method in KeycloakAdapter to fetch a user's data through Keycloak's Admin API.
Adds annotation to remove members field from GroupsDTO when empty or null.
Refactors client and realm roles fetching to avoid NPE by using Optional objects instead.
Adds and updates respective unit tests.

These changes close #105 