### PR TITLE
feat(users-management): adds POST endpoint to join user as member of a group

### DIFF
--- a/backend/src/main/java/io/littlehorse/usertasks/controllers/UserManagementController.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/controllers/UserManagementController.java
@@ -3,6 +3,7 @@ package io.littlehorse.usertasks.controllers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.littlehorse.usertasks.configurations.CustomIdentityProviderProperties;
 import io.littlehorse.usertasks.configurations.IdentityProviderConfigProperties;
+import io.littlehorse.usertasks.exceptions.NotFoundException;
 import io.littlehorse.usertasks.idp_adapters.IStandardIdentityProviderAdapter;
 import io.littlehorse.usertasks.idp_adapters.IdentityProviderVendor;
 import io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter;
@@ -510,6 +511,61 @@ public class UserManagementController {
         } catch (JsonProcessingException e) {
             log.error("Something went wrong when getting claims from token while trying to remove admin role.");
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(
+            summary = "Join Group",
+            description = "Allows a user to join a group."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Tenant Id is not valid.",
+                    content = {@Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProblemDetail.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "User or Group could not be found.",
+                    content = {@Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProblemDetail.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "406",
+                    description = "Unknown Identity vendor.",
+                    content = {@Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProblemDetail.class))}
+            )
+    })
+    @PostMapping("/{tenant_id}/management/users/{user_id}/groups/{group_id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void joinGroup(@RequestHeader(name = "Authorization") String accessToken,
+                          @PathVariable(name = "tenant_id") String tenantId,
+                          @PathVariable(name = "user_id") String userId,
+                          @PathVariable(name = "group_id") String groupId) {
+        if (!tenantService.isValidTenant(tenantId, accessToken)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+
+        try {
+            CustomIdentityProviderProperties customIdentityProviderProperties =
+                    getCustomIdentityProviderProperties(accessToken, identityProviderConfigProperties);
+            IStandardIdentityProviderAdapter identityProviderHandler = getIdentityProviderHandler(customIdentityProviderProperties.getVendor());
+
+            userManagementService.joinGroup(accessToken, userId, groupId, identityProviderHandler);
+        } catch (JsonProcessingException e) {
+            log.error("Something went wrong when getting claims from token while joining a user to a group.");
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (NotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
     }
 

--- a/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
@@ -42,4 +42,6 @@ public interface IStandardIdentityProviderAdapter {
     void assignAdminRole(Map<String, Object> params);
 
     void removeAdminRole(Map<String, Object> params);
+
+    void joinGroup(Map<String, Object> params);
 }

--- a/backend/src/main/java/io/littlehorse/usertasks/services/UserManagementService.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/services/UserManagementService.java
@@ -16,8 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter.ACCESS_TOKEN_MAP_KEY;
-import static io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter.USER_ID_MAP_KEY;
+import static io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter.*;
 
 @Service
 @Slf4j
@@ -90,5 +89,13 @@ public class UserManagementService {
         Map<String, Object> params = Map.of(ACCESS_TOKEN_MAP_KEY, accessToken, USER_ID_MAP_KEY, userId);
 
         identityProviderHandler.removeAdminRole(params);
+    }
+
+    public void joinGroup(@NonNull String accessToken, @NonNull String userId, @NonNull String groupId,
+                          @NonNull IStandardIdentityProviderAdapter identityProviderHandler) {
+        Map<String, Object> params = Map.of(ACCESS_TOKEN_MAP_KEY, accessToken, USER_ID_MAP_KEY, userId,
+                USER_GROUP_ID_MAP_KEY, groupId);
+
+        identityProviderHandler.joinGroup(params);
     }
 }

--- a/backend/src/test/java/io/littlehorse/usertasks/services/UserManagementServiceTest.java
+++ b/backend/src/test/java/io/littlehorse/usertasks/services/UserManagementServiceTest.java
@@ -660,6 +660,50 @@ class UserManagementServiceTest {
         assertTrue(StringUtils.equalsIgnoreCase(fakeUserId, (String) paramsSent.get("userId")));
     }
 
+    @Test
+    void joinGroup_shouldThrowNullPointerExceptionWhenNullAccessTokenIsReceived() {
+        assertThrows(NullPointerException.class, ()-> userManagementService.joinGroup(null, "userId",
+                "groupId", keycloakAdapter));
+    }
+
+    @Test
+    void joinGroup_shouldThrowNullPointerExceptionWhenNullUserIdIsReceived() {
+        assertThrows(NullPointerException.class, ()-> userManagementService.joinGroup(fakeAccessToken, null,
+                "groupId", keycloakAdapter));
+    }
+
+    @Test
+    void joinGroup_shouldThrowNullPointerExceptionWhenNullGroupIdIsReceived() {
+        assertThrows(NullPointerException.class, ()-> userManagementService.joinGroup(fakeAccessToken, "userId",
+                null, keycloakAdapter));
+    }
+
+    @Test
+    void joinGroup_shouldThrowNullPointerExceptionWhenNullIdentityProviderAdapterIsReceived() {
+        assertThrows(NullPointerException.class, ()-> userManagementService.joinGroup(fakeAccessToken, "userId",
+                "groupId", null));
+    }
+
+    @Test
+    void joinGroup_shouldSucceedWhenNoExceptionsAreThrown() {
+        String fakeUserId = UUID.randomUUID().toString();
+        String fakeGroupId = UUID.randomUUID().toString();
+
+        userManagementService.joinGroup(fakeAccessToken, fakeUserId, fakeGroupId, keycloakAdapter);
+
+        ArgumentCaptor<Map<String, Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+
+        verify(keycloakAdapter).joinGroup(argumentCaptor.capture());
+
+        Map<String, Object> paramsSent = argumentCaptor.getValue();
+
+        int expectedParamsCount = 3;
+
+        assertEquals(expectedParamsCount, paramsSent.size());
+        assertTrue(StringUtils.equalsIgnoreCase(fakeUserId, (String) paramsSent.get("userId")));
+        assertTrue(StringUtils.equalsIgnoreCase(fakeGroupId, (String) paramsSent.get("userGroupId")));
+    }
+
     private void assertMandatoryParamsForKeycloakSearch(Map<String, Object> paramsUsedToSearchUsers, int expectedParamsCount) {
         assertTrue(paramsUsedToSearchUsers.containsKey("firstResult"));
         assertTrue(paramsUsedToSearchUsers.containsKey("maxResults"));


### PR DESCRIPTION
Adds respective OpenAPI Spec docs.
Implements a method in KeycloakAdapter to join a user as member of a group through Keycloak's Admin API.
Removes unnecessary null check when fetching user resource.
Adds respective unit tests.