### PR TITLE
feat(users-management): adds DELETE endpoint to remove a user as member of a group

### DIFF
--- a/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
@@ -44,4 +44,6 @@ public interface IStandardIdentityProviderAdapter {
     void removeAdminRole(Map<String, Object> params);
 
     void joinGroup(Map<String, Object> params);
+
+    void removeUserFromGroup(Map<String, Object> params);
 }

--- a/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/keycloak/KeycloakAdapter.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/keycloak/KeycloakAdapter.java
@@ -511,6 +511,32 @@ public class KeycloakAdapter implements IStandardIdentityProviderAdapter {
         }
     }
 
+    @Override
+    public void removeUserFromGroup(Map<String, Object> params) {
+        log.info("Starting to remove user as group member!");
+
+        var accessToken = (String) params.get(ACCESS_TOKEN_MAP_KEY);
+        var realm = getRealmFromToken(accessToken);
+        var userId = (String) params.get(USER_ID_MAP_KEY);
+        var groupId = (String) params.get(USER_GROUP_ID_MAP_KEY);
+
+        try (Keycloak keycloak = getKeycloakInstance(realm, accessToken)) {
+            keycloak.realm(realm).users().get(userId).leaveGroup(groupId);
+
+            log.info("User successfully removed from group!");
+        } catch (AdapterException e) {
+            log.error(e.getMessage());
+            throw new AdapterException(e.getMessage());
+        } catch (NotFoundException e) {
+            log.error(e.getMessage());
+            throw new io.littlehorse.usertasks.exceptions.NotFoundException("User or Group could not be found.");
+        } catch (Exception e) {
+            var errorMessage = "Something went wrong while removing user from group in Keycloak realm.";
+            log.error(errorMessage, e);
+            throw new AdapterException(errorMessage);
+        }
+    }
+
     public static Map<String, Object> buildParamsForUsersSearch(String accessToken, IDPUserSearchRequestFilter requestFilter,
                                                                 int firstResult, int maxResults) {
         Map<String, Object> params = new HashMap<>();

--- a/backend/src/main/java/io/littlehorse/usertasks/services/UserManagementService.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/services/UserManagementService.java
@@ -98,4 +98,11 @@ public class UserManagementService {
 
         identityProviderHandler.joinGroup(params);
     }
+
+    public void removeUserFromGroup(@NonNull String accessToken, @NonNull String userId, @NonNull String groupId,
+                                    @NonNull IStandardIdentityProviderAdapter identityProviderHandler) {
+        Map<String, Object> params = Map.of(ACCESS_TOKEN_MAP_KEY, accessToken, USER_ID_MAP_KEY, userId, USER_GROUP_ID_MAP_KEY, groupId);
+
+        identityProviderHandler.removeUserFromGroup(params);
+    }
 }

--- a/backend/src/test/java/io/littlehorse/usertasks/services/UserManagementServiceTest.java
+++ b/backend/src/test/java/io/littlehorse/usertasks/services/UserManagementServiceTest.java
@@ -704,6 +704,50 @@ class UserManagementServiceTest {
         assertTrue(StringUtils.equalsIgnoreCase(fakeGroupId, (String) paramsSent.get("userGroupId")));
     }
 
+    @Test
+    void removeUserFromGroup_shouldThrowNullPointerExceptionWhenNullAccessTokenIsReceived() {
+        assertThrows(NullPointerException.class,
+                ()-> userManagementService.removeUserFromGroup(null, "someUserId", "someGroupId", keycloakAdapter));
+    }
+
+    @Test
+    void removeUserFromGroup_shouldThrowNullPointerExceptionWhenNullUserIdIsReceived() {
+        assertThrows(NullPointerException.class,
+                ()-> userManagementService.removeUserFromGroup(fakeAccessToken, null, "someGroupId", keycloakAdapter));
+    }
+
+    @Test
+    void removeUserFromGroup_shouldThrowNullPointerExceptionWhenNullGroupIdIsReceived() {
+        assertThrows(NullPointerException.class,
+                ()-> userManagementService.removeUserFromGroup(fakeAccessToken, "someUserId", null, keycloakAdapter));
+    }
+
+    @Test
+    void removeUserFromGroup_shouldThrowNullPointerExceptionWhenNullIdentityProviderAdapterIsReceived() {
+        assertThrows(NullPointerException.class,
+                ()-> userManagementService.removeUserFromGroup(fakeAccessToken, "someUserId", "someUserId", null));
+    }
+
+    @Test
+    void removeUserFromGroup_shouldSucceedWhenNoExceptionsAreThrown() {
+        var userId = UUID.randomUUID().toString();
+        var groupId = UUID.randomUUID().toString();
+
+        userManagementService.removeUserFromGroup(fakeAccessToken, userId, groupId, keycloakAdapter);
+
+        ArgumentCaptor<Map<String, Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+
+        verify(keycloakAdapter).removeUserFromGroup(argumentCaptor.capture());
+
+        Map<String, Object> paramsSent = argumentCaptor.getValue();
+
+        int expectedParamsCount = 3;
+
+        assertEquals(expectedParamsCount, paramsSent.size());
+        assertTrue(StringUtils.equalsIgnoreCase(userId, (String) paramsSent.get("userId")));
+        assertTrue(StringUtils.equalsIgnoreCase(groupId, (String) paramsSent.get("userGroupId")));
+    }
+
     private void assertMandatoryParamsForKeycloakSearch(Map<String, Object> paramsUsedToSearchUsers, int expectedParamsCount) {
         assertTrue(paramsUsedToSearchUsers.containsKey("firstResult"));
         assertTrue(paramsUsedToSearchUsers.containsKey("maxResults"));


### PR DESCRIPTION
Adds respective OpenAPI Spec docs.
Implements a method in KeycloakAdapter to remove a user as member of a group through Keycloak's Admin API.
Adds respective unit tests.

This PR closes #106 