### PR TITLE
feat(groups-management): adds POST endpoint to create a group with a name

### DIFF
--- a/backend/src/main/java/io/littlehorse/usertasks/controllers/GroupManagementController.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/controllers/GroupManagementController.java
@@ -1,0 +1,132 @@
+package io.littlehorse.usertasks.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.littlehorse.usertasks.configurations.CustomIdentityProviderProperties;
+import io.littlehorse.usertasks.configurations.IdentityProviderConfigProperties;
+import io.littlehorse.usertasks.idp_adapters.IStandardIdentityProviderAdapter;
+import io.littlehorse.usertasks.idp_adapters.IdentityProviderVendor;
+import io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter;
+import io.littlehorse.usertasks.models.requests.CreateGroupRequest;
+import io.littlehorse.usertasks.services.GroupManagementService;
+import io.littlehorse.usertasks.services.TenantService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.*;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.littlehorse.usertasks.configurations.CustomIdentityProviderProperties.getCustomIdentityProviderProperties;
+import static io.littlehorse.usertasks.util.constants.AuthoritiesConstants.LH_USER_TASKS_ADMIN_ROLE;
+
+@Tag(
+        name = "User Management Controller",
+        description = "This is a controller that exposes endpoints in charge of handling requests related to managing users"
+)
+@RestController
+@CrossOrigin
+@PreAuthorize("isAuthenticated() && hasAuthority('" + LH_USER_TASKS_ADMIN_ROLE + "')")
+@Slf4j
+public class GroupManagementController {
+    private final TenantService tenantService;
+    private final GroupManagementService groupManagementService;
+    private final IdentityProviderConfigProperties identityProviderConfigProperties;
+
+    public GroupManagementController(TenantService tenantService, GroupManagementService groupManagementService,
+                                     IdentityProviderConfigProperties identityProviderConfigProperties) {
+        this.tenantService = tenantService;
+        this.groupManagementService = groupManagementService;
+        this.identityProviderConfigProperties = identityProviderConfigProperties;
+    }
+
+    @Operation(
+            summary = "Create Group",
+            description = "Creates a Group within a specific tenant's IdP"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Tenant Id is not valid.",
+                    content = {@Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProblemDetail.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "406",
+                    description = "Unknown Identity vendor.",
+                    content = {@Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProblemDetail.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "Name is already used by an existing group.",
+                    content = {@Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProblemDetail.class))}
+            )
+    })
+    @PostMapping("/{tenant_id}/management/groups")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createGroup(@RequestHeader(name = "Authorization") String accessToken,
+                            @PathVariable(name = "tenant_id") String tenantId,
+                            @RequestBody CreateGroupRequest requestBody) {
+        if (!tenantService.isValidTenant(tenantId, accessToken)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        }
+
+        try {
+            CustomIdentityProviderProperties customIdentityProviderProperties =
+                    getCustomIdentityProviderProperties(accessToken, identityProviderConfigProperties);
+            IStandardIdentityProviderAdapter identityProviderHandler = getIdentityProviderHandler(customIdentityProviderProperties.getVendor());
+
+            validateRequestBody(requestBody);
+
+            groupManagementService.createGroupInIdentityProvider(accessToken, requestBody, identityProviderHandler);
+        } catch (JsonProcessingException e) {
+            log.error("Something went wrong when getting claims from token while trying to create a group.");
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (ValidationException e) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+        }
+    }
+
+    private IStandardIdentityProviderAdapter getIdentityProviderHandler(@NonNull IdentityProviderVendor vendor) {
+        if (vendor == IdentityProviderVendor.KEYCLOAK) {
+            return new KeycloakAdapter();
+        } else {
+            throw new ResponseStatusException(HttpStatus.NOT_ACCEPTABLE);
+        }
+    }
+
+    private void validateRequestBody(CreateGroupRequest requestBody) {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            Validator validator = factory.getValidator();
+            Set<ConstraintViolation<CreateGroupRequest>> constraintViolations = validator.validate(requestBody);
+
+            if (!CollectionUtils.isEmpty(constraintViolations)) {
+                String validationMessage = constraintViolations.stream()
+                        .map(ConstraintViolation::getMessage)
+                        .collect(Collectors.joining("; "));
+
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, validationMessage);
+            }
+        }
+    }
+}

--- a/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
@@ -46,4 +46,6 @@ public interface IStandardIdentityProviderAdapter {
     void joinGroup(Map<String, Object> params);
 
     void removeUserFromGroup(Map<String, Object> params);
+
+    void createGroup(Map<String, Object> params);
 }

--- a/backend/src/main/java/io/littlehorse/usertasks/models/requests/CreateGroupRequest.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/models/requests/CreateGroupRequest.java
@@ -1,0 +1,14 @@
+package io.littlehorse.usertasks.models.requests;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateGroupRequest {
+    @NotBlank
+    private String name;
+}

--- a/backend/src/main/java/io/littlehorse/usertasks/services/GroupManagementService.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/services/GroupManagementService.java
@@ -1,0 +1,31 @@
+package io.littlehorse.usertasks.services;
+
+import io.littlehorse.usertasks.idp_adapters.IStandardIdentityProviderAdapter;
+import io.littlehorse.usertasks.models.common.UserGroupDTO;
+import io.littlehorse.usertasks.models.requests.CreateGroupRequest;
+import jakarta.validation.ValidationException;
+import lombok.NonNull;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter.ACCESS_TOKEN_MAP_KEY;
+import static io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter.USER_GROUP_NAME_MAP_KEY;
+
+@Service
+public class GroupManagementService {
+
+    public void createGroupInIdentityProvider(@NonNull String accessToken, @NonNull CreateGroupRequest request,
+                                              @NonNull IStandardIdentityProviderAdapter identityProviderAdapter) {
+        Map<String, Object> params = Map.of(ACCESS_TOKEN_MAP_KEY, accessToken, USER_GROUP_NAME_MAP_KEY, request.getName());
+
+        UserGroupDTO userGroup = identityProviderAdapter.getUserGroup(params);
+
+        if (Objects.nonNull(userGroup)) {
+            throw new ValidationException("Group already exists with the requested name!");
+        }
+
+        identityProviderAdapter.createGroup(params);
+    }
+}

--- a/backend/src/test/java/io/littlehorse/usertasks/services/GroupManagementServiceTest.java
+++ b/backend/src/test/java/io/littlehorse/usertasks/services/GroupManagementServiceTest.java
@@ -1,0 +1,90 @@
+package io.littlehorse.usertasks.services;
+
+import io.littlehorse.usertasks.idp_adapters.IStandardIdentityProviderAdapter;
+import io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter;
+import io.littlehorse.usertasks.models.common.UserGroupDTO;
+import io.littlehorse.usertasks.models.requests.CreateGroupRequest;
+import jakarta.validation.ValidationException;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+class GroupManagementServiceTest {
+    private final GroupManagementService groupManagementService = new GroupManagementService();
+
+    private final IStandardIdentityProviderAdapter keycloakAdapter = mock(KeycloakAdapter.class);
+
+    String fakeAccessToken = "some-fake-access-token";
+
+    @Test
+    void createGroupInIdentityProvider_shouldThrowNullPointerExceptionWhenNullAccessTokenIsReceived() {
+        CreateGroupRequest request = new CreateGroupRequest("some-group");
+
+        assertThrows(NullPointerException.class,
+                ()-> groupManagementService.createGroupInIdentityProvider(null, request, keycloakAdapter));
+    }
+
+    @Test
+    void createGroupInIdentityProvider_shouldThrowNullPointerExceptionWhenNullRequestIsReceived() {
+        assertThrows(NullPointerException.class,
+                ()-> groupManagementService.createGroupInIdentityProvider(fakeAccessToken, null, keycloakAdapter));
+    }
+
+    @Test
+    void createGroupInIdentityProvider_shouldThrowNullPointerExceptionWhenNullIdentityProviderAdapterIsReceived() {
+        CreateGroupRequest request = new CreateGroupRequest("some-group");
+
+        assertThrows(NullPointerException.class,
+                ()-> groupManagementService.createGroupInIdentityProvider(fakeAccessToken, request, null));
+    }
+
+    @Test
+    void createGroupInIdentityProvider_shouldThrowValidationExceptionWhenNameIsAlreadyUsedByExistingGroup() {
+        var groupName = "some-group";
+        CreateGroupRequest request = new CreateGroupRequest(groupName);
+
+        UserGroupDTO foundGroup = UserGroupDTO.builder()
+                .id("some-id")
+                .name(groupName)
+                .build();
+
+        when(keycloakAdapter.getUserGroup(anyMap())).thenReturn(foundGroup);
+
+        ValidationException thrownException = assertThrows(ValidationException.class,
+                () -> groupManagementService.createGroupInIdentityProvider(fakeAccessToken, request, keycloakAdapter));
+
+        var expectedErrorMessage = "Group already exists with the requested name!";
+        assertTrue(StringUtils.equalsIgnoreCase(expectedErrorMessage, thrownException.getMessage()));
+
+        verify(keycloakAdapter).getUserGroup(anyMap());
+        verify(keycloakAdapter, never()).createGroup(anyMap());
+    }
+
+    @Test
+    void createGroupInIdentityProvider_shouldSucceedWhenNoExceptionsAreThrown() {
+        var groupName = "some-group";
+        CreateGroupRequest request = new CreateGroupRequest(groupName);
+
+        when(keycloakAdapter.getUserGroup(anyMap())).thenReturn(null);
+
+        groupManagementService.createGroupInIdentityProvider(fakeAccessToken, request, keycloakAdapter);
+
+        ArgumentCaptor<Map<String, Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+
+        verify(keycloakAdapter).getUserGroup(anyMap());
+        verify(keycloakAdapter).createGroup(argumentCaptor.capture());
+
+        Map<String, Object> paramsSent = argumentCaptor.getValue();
+
+        int expectedParamsCount = 2;
+        assertEquals(expectedParamsCount, paramsSent.size());
+        assertTrue(StringUtils.equalsIgnoreCase(groupName, (String) paramsSent.get("userGroupName")));
+    }
+}


### PR DESCRIPTION
Adds respective OpenAPI Spec docs.
Adds new controller to handle Group's management requests.
Adds CreateGroupRequest to map request body used when creating groups.
Implements a method in KeycloakAdapter to create a group through Keycloak's Admin API.
Adds respective unit tests.