### PR TITLE
feat(users-management): adds GET endpoint to fetch groups from IdP

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,6 @@ configured Identity Provider.
 - IMPORTANT: These endpoints will **_only work with Keycloak_** as Identity Provider, for there's only one IdP adapter currently implemented.
 - These endpoints are set to only allow Admin users to hit them
 - In order to properly manage users, besides having the `lh-user-tasks-admin` role that identifies Users as Admins,
-they also need to have the `manage-users` role assigned.
+they also need to have the `manage-users` and `view-realm` roles assigned.
 
 **In case that all Admin users were deleted, you will need to create at least 1 by using your Identity Provider's dashboard.**

--- a/backend/src/main/java/io/littlehorse/usertasks/controllers/UserManagementController.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/controllers/UserManagementController.java
@@ -201,6 +201,13 @@ public class UserManagementController {
                             schema = @Schema(implementation = ProblemDetail.class))}
             ),
             @ApiResponse(
+                    responseCode = "404",
+                    description = "User could not be found.",
+                    content = {@Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ProblemDetail.class))}
+            ),
+            @ApiResponse(
                     responseCode = "406",
                     description = "Unknown Identity vendor.",
                     content = {@Content(
@@ -229,6 +236,8 @@ public class UserManagementController {
         } catch (JsonProcessingException e) {
             log.error("Something went wrong when getting claims from token while trying to upsert a user's password.");
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (NotFoundException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
         }
     }
 

--- a/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
@@ -2,12 +2,10 @@ package io.littlehorse.usertasks.idp_adapters;
 
 import io.littlehorse.usertasks.models.common.UserDTO;
 import io.littlehorse.usertasks.models.common.UserGroupDTO;
-import io.littlehorse.usertasks.models.responses.IDPUserDTO;
-import io.littlehorse.usertasks.models.responses.IDPUserListDTO;
-import io.littlehorse.usertasks.models.responses.UserGroupListDTO;
-import io.littlehorse.usertasks.models.responses.UserListDTO;
+import io.littlehorse.usertasks.models.responses.*;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Interface that defines standard IdP methods to be implemented in all the IdP custom adapters
@@ -48,4 +46,6 @@ public interface IStandardIdentityProviderAdapter {
     void removeUserFromGroup(Map<String, Object> params);
 
     void createGroup(Map<String, Object> params);
+
+    Set<IDPGroupDTO> getGroups(Map<String, Object> params);
 }

--- a/backend/src/main/java/io/littlehorse/usertasks/models/responses/IDPGroupDTO.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/models/responses/IDPGroupDTO.java
@@ -1,17 +1,9 @@
 package io.littlehorse.usertasks.models.responses;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
 import org.keycloak.representations.idm.GroupRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
-import org.springframework.util.CollectionUtils;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * {@code IDPGroupDTO} is a Data Transfer Object that contains information about a specific Group from an Identity Provider.
@@ -20,10 +12,10 @@ import java.util.stream.Collectors;
 @Builder
 @Data
 public class IDPGroupDTO {
+    @NotBlank
     private String id;
+    @NotBlank
     private String name;
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private Set<IDPUserDTO> members;
 
     /**
      * Transforms a {@code GroupRepresentation}, and optionally its respective collection of {@code UserRepresentation} (members),
@@ -32,24 +24,10 @@ public class IDPGroupDTO {
      * @see org.keycloak.representations.idm.GroupRepresentation
      * @see org.keycloak.representations.idm.UserRepresentation
      */
-    public static IDPGroupDTO transform(GroupRepresentation groupRepresentation, Collection<UserRepresentation> usersRepresentation) {
-        Set<IDPUserDTO> foundMembers = getMembersFromKeycloakUserRepresentation(usersRepresentation);
-
+    public static IDPGroupDTO transform(GroupRepresentation groupRepresentation) {
         return IDPGroupDTO.builder()
                 .id(groupRepresentation.getId())
                 .name(groupRepresentation.getName())
-                .members(foundMembers)
                 .build();
-    }
-
-    private static Set<IDPUserDTO> getMembersFromKeycloakUserRepresentation(Collection<UserRepresentation> usersRepresentation) {
-        if (!CollectionUtils.isEmpty(usersRepresentation)) {
-            return usersRepresentation.stream()
-                    .filter(Objects::nonNull)
-                    .map(userRepresentation -> IDPUserDTO.transform(userRepresentation, null))
-                    .collect(Collectors.toUnmodifiableSet());
-        }
-
-        return Collections.emptySet();
     }
 }

--- a/backend/src/main/java/io/littlehorse/usertasks/models/responses/IDPGroupListDTO.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/models/responses/IDPGroupListDTO.java
@@ -1,0 +1,21 @@
+package io.littlehorse.usertasks.models.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+/**
+ * {@code IDPGroupListDTO} is a Data Transfer Object that contains a Set of {@code io.littlehorse.usertasks.models.responses.IDPGroupDTO}
+ *
+ * @see IDPGroupDTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IDPGroupListDTO {
+    private Set<IDPGroupDTO> groups;
+}

--- a/backend/src/main/java/io/littlehorse/usertasks/models/responses/IDPUserDTO.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/models/responses/IDPUserDTO.java
@@ -75,7 +75,7 @@ public class IDPUserDTO {
         if (!CollectionUtils.isEmpty(groupsRepresentation)) {
             return groupsRepresentation.stream()
                     .filter(Objects::nonNull)
-                    .map(groupRepresentation -> IDPGroupDTO.transform(groupRepresentation, null))
+                    .map(groupRepresentation -> IDPGroupDTO.transform(groupRepresentation))
                     .collect(Collectors.toUnmodifiableSet());
         }
 

--- a/backend/src/main/java/io/littlehorse/usertasks/services/GroupManagementService.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/services/GroupManagementService.java
@@ -3,15 +3,18 @@ package io.littlehorse.usertasks.services;
 import io.littlehorse.usertasks.idp_adapters.IStandardIdentityProviderAdapter;
 import io.littlehorse.usertasks.models.common.UserGroupDTO;
 import io.littlehorse.usertasks.models.requests.CreateGroupRequest;
+import io.littlehorse.usertasks.models.responses.IDPGroupDTO;
 import jakarta.validation.ValidationException;
 import lombok.NonNull;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
-import static io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter.ACCESS_TOKEN_MAP_KEY;
-import static io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter.USER_GROUP_NAME_MAP_KEY;
+import static io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter.*;
 
 @Service
 public class GroupManagementService {
@@ -27,5 +30,19 @@ public class GroupManagementService {
         }
 
         identityProviderAdapter.createGroup(params);
+    }
+
+    public Set<IDPGroupDTO> getGroups(@NonNull String accessToken, @Nullable String name, int firstResult, int maxResults,
+                                      @NonNull IStandardIdentityProviderAdapter identityProviderHandler) {
+        Map<String, Object> params = new HashMap<>();
+
+        params.put(ACCESS_TOKEN_MAP_KEY, accessToken);
+        params.put(USER_GROUP_NAME_MAP_KEY, name);
+        params.put(FIRST_RESULT_MAP_KEY, firstResult);
+        params.put(MAX_RESULTS_MAP_KEY, maxResults);
+
+        params.entrySet().removeIf(entry -> Objects.isNull(entry.getValue()));
+
+        return identityProviderHandler.getGroups(params);
     }
 }

--- a/backend/src/test/java/io/littlehorse/usertasks/services/GroupManagementServiceTest.java
+++ b/backend/src/test/java/io/littlehorse/usertasks/services/GroupManagementServiceTest.java
@@ -4,12 +4,17 @@ import io.littlehorse.usertasks.idp_adapters.IStandardIdentityProviderAdapter;
 import io.littlehorse.usertasks.idp_adapters.keycloak.KeycloakAdapter;
 import io.littlehorse.usertasks.models.common.UserGroupDTO;
 import io.littlehorse.usertasks.models.requests.CreateGroupRequest;
+import io.littlehorse.usertasks.models.responses.IDPGroupDTO;
 import jakarta.validation.ValidationException;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.util.CollectionUtils;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -17,6 +22,8 @@ import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")
 class GroupManagementServiceTest {
+    public static final int FIRST_RESULT_DEFAULT = 0;
+    public static final int MAX_RESULTS_DEFAULT = 10;
     private final GroupManagementService groupManagementService = new GroupManagementService();
 
     private final IStandardIdentityProviderAdapter keycloakAdapter = mock(KeycloakAdapter.class);
@@ -86,5 +93,121 @@ class GroupManagementServiceTest {
         int expectedParamsCount = 2;
         assertEquals(expectedParamsCount, paramsSent.size());
         assertTrue(StringUtils.equalsIgnoreCase(groupName, (String) paramsSent.get("userGroupName")));
+    }
+
+    @Test
+    void getGroups_shouldThrowNullPointerExceptionWhenNullAccessTokenIsReceived() {
+        assertThrows(NullPointerException.class,
+                ()-> groupManagementService.getGroups(null, null, FIRST_RESULT_DEFAULT, MAX_RESULTS_DEFAULT, keycloakAdapter));
+    }
+
+    @Test
+    void getGroups_shouldThrowNullPointerExceptionWhenNullIdentityProviderAdapterIsReceived() {
+        assertThrows(NullPointerException.class,
+                ()-> groupManagementService.getGroups(fakeAccessToken, null, FIRST_RESULT_DEFAULT, MAX_RESULTS_DEFAULT, null));
+    }
+
+    @Test
+    void getGroups_shouldSucceedWhenNoExceptionsAreThrownAndNoNameIsReceivedAndNoGroupsAreFound() {
+        when(keycloakAdapter.getGroups(anyMap())).thenReturn(Collections.emptySet());
+
+        Set<IDPGroupDTO> foundGroups = groupManagementService.getGroups(fakeAccessToken, null, FIRST_RESULT_DEFAULT, MAX_RESULTS_DEFAULT, keycloakAdapter);
+
+        assertTrue(CollectionUtils.isEmpty(foundGroups));
+
+        ArgumentCaptor<Map<String, Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+
+        verify(keycloakAdapter).getGroups(argumentCaptor.capture());
+
+        Map<String, Object> paramsSent = argumentCaptor.getValue();
+
+        int expectedParamsCount = 3;
+        int expectedFirstResult = 0;
+        int expectedMaxResults = 10;
+
+        assertEquals(expectedParamsCount, paramsSent.size());
+        assertEquals(expectedFirstResult, paramsSent.get("firstResult"));
+        assertEquals(expectedMaxResults, paramsSent.get("maxResults"));
+    }
+
+    @Test
+    void getGroups_shouldSucceedWhenNoExceptionsAreThrownAndNoNameIsReceivedAndGroupsAreFound() {
+        IDPGroupDTO group1 = IDPGroupDTO.builder()
+                .id(UUID.randomUUID().toString())
+                .name("my-group-1")
+                .build();
+
+        IDPGroupDTO group2 = IDPGroupDTO.builder()
+                .id(UUID.randomUUID().toString())
+                .name("my-group-2")
+                .build();
+
+        Set<IDPGroupDTO> mappedGroups = Set.of(group1, group2);
+
+        when(keycloakAdapter.getGroups(anyMap())).thenReturn(mappedGroups);
+
+        Set<IDPGroupDTO> foundGroups = groupManagementService.getGroups(fakeAccessToken, null, FIRST_RESULT_DEFAULT, MAX_RESULTS_DEFAULT, keycloakAdapter);
+
+        int expectedGroupsCount = 2;
+
+        assertEquals(expectedGroupsCount, foundGroups.size());
+
+        ArgumentCaptor<Map<String, Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+
+        verify(keycloakAdapter).getGroups(argumentCaptor.capture());
+
+        Map<String, Object> paramsSent = argumentCaptor.getValue();
+
+        int expectedParamsCount = 3;
+        int expectedFirstResult = 0;
+        int expectedMaxResults = 10;
+
+        assertEquals(expectedParamsCount, paramsSent.size());
+        assertEquals(expectedFirstResult, paramsSent.get("firstResult"));
+        assertEquals(expectedMaxResults, paramsSent.get("maxResults"));
+    }
+
+    @Test
+    void getGroups_shouldSucceedWhenNoExceptionsAreThrownAndNameIsReceivedAndGroupsAreFound() {
+        IDPGroupDTO group1 = IDPGroupDTO.builder()
+                .id(UUID.randomUUID().toString())
+                .name("my-group-1")
+                .build();
+
+        IDPGroupDTO group2 = IDPGroupDTO.builder()
+                .id(UUID.randomUUID().toString())
+                .name("my-group-2")
+                .build();
+
+        IDPGroupDTO group3 = IDPGroupDTO.builder()
+                .id(UUID.randomUUID().toString())
+                .name("my-group-3")
+                .build();
+
+        var searchingName = "my-grou";
+
+        Set<IDPGroupDTO> mappedGroups = Set.of(group1, group2, group3);
+
+        when(keycloakAdapter.getGroups(anyMap())).thenReturn(mappedGroups);
+
+        Set<IDPGroupDTO> foundGroups = groupManagementService.getGroups(fakeAccessToken, searchingName, FIRST_RESULT_DEFAULT, MAX_RESULTS_DEFAULT, keycloakAdapter);
+
+        int expectedGroupsCount = 3;
+
+        assertEquals(expectedGroupsCount, foundGroups.size());
+
+        ArgumentCaptor<Map<String, Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+
+        verify(keycloakAdapter).getGroups(argumentCaptor.capture());
+
+        Map<String, Object> paramsSent = argumentCaptor.getValue();
+
+        int expectedParamsCount = 4;
+        int expectedFirstResult = 0;
+        int expectedMaxResults = 10;
+
+        assertEquals(expectedParamsCount, paramsSent.size());
+        assertEquals(expectedFirstResult, paramsSent.get("firstResult"));
+        assertEquals(expectedMaxResults, paramsSent.get("maxResults"));
     }
 }

--- a/local-dev/keycloak-configurer/configure-keycloak.sh
+++ b/local-dev/keycloak-configurer/configure-keycloak.sh
@@ -152,6 +152,7 @@ configure_keycloak() {
    VIEW_USERS_ROLE_ID=$(http --ignore-stdin -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/ui-ext/available-roles/users/${NON_ADMIN_USER_ID}?first=0&max=1&search=view-users" | jq -r ".[0].id")
    USER_TASKS_BRIDGE_ADMIN_ROLE_ID=$(http --ignore-stdin -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/roles/lh-user-tasks-admin" | jq -r ".id")
    MANAGE_USERS_ROLE_ID=$(http --ignore-stdin -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/clients/${REALM_MANAGEMENT_CLIENT_ID}/roles/manage-users" | jq -r ".id")
+   VIEW_REALM_ROLE_ID=$(http --ignore-stdin -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/clients/${REALM_MANAGEMENT_CLIENT_ID}/roles/view-realm" | jq -r ".id")
 
 #  Here we assign the view-users role to the nonAdmin user, and subsequently to the admin user as well. The view-users role
 #  allows users to see their userInfo details.
@@ -175,6 +176,12 @@ configure_keycloak() {
    http --ignore-stdin -b -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" POST "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/users/${ADMIN_USER_ID}/role-mappings/clients/${REALM_MANAGEMENT_CLIENT_ID}" \
               [0][id]="$MANAGE_USERS_ROLE_ID" \
               [0][name]="manage-users"
+
+# The view-realm role allows admin users to see resources such as roles from a Keycloak realm
+   echo "Assigning manage-users Role to Admin User"
+   http --ignore-stdin -b -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" POST "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/users/${ADMIN_USER_ID}/role-mappings/clients/${REALM_MANAGEMENT_CLIENT_ID}" \
+              [0][id]="$VIEW_REALM_ROLE_ID" \
+              [0][name]="view-realm"
 
    echo "Roles successfully assigned to users!"
 


### PR DESCRIPTION
Adds respective OpenAPI Spec docs.
Remove members property from IDPGroupDTO as it is not required.
Adds IDPGroupListDTO to properly represent the response body of the newly introduced endpoint.
Adds missing exception handling logic when trying to set a password to a non-existent user.
Sets a user as enabled since its creation.
Implements a method in KeycloakAdapter to fetch a collection of groups through Keycloak's Admin API.
Adds view-realm role to Admin user in script used to deploy local development environment.
Adds respective unit tests.
Updates README.