### PR TITLE
feat(groups-management): adds PUT endpoint to update groups from IdP

### DIFF
--- a/backend/src/main/java/io/littlehorse/usertasks/controllers/UserManagementController.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/controllers/UserManagementController.java
@@ -384,7 +384,7 @@ public class UserManagementController {
     public void deleteUser(@RequestHeader(name = "Authorization") String accessToken,
                            @PathVariable(name = "tenant_id") String tenantId,
                            @PathVariable(name = "user_id") String userId,
-                           @RequestParam(required = false) boolean ignoreOrphanTasks) {
+                           @RequestParam(name = "ignore_orphan_tasks", required = false) boolean ignoreOrphanTasks) {
         if (!tenantService.isValidTenant(tenantId, accessToken)) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
         }

--- a/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
@@ -48,4 +48,6 @@ public interface IStandardIdentityProviderAdapter {
     void createGroup(Map<String, Object> params);
 
     Set<IDPGroupDTO> getGroups(Map<String, Object> params);
+
+    void updateGroup(Map<String, Object> params);
 }

--- a/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/keycloak/KeycloakAdapter.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/keycloak/KeycloakAdapter.java
@@ -609,6 +609,33 @@ public class KeycloakAdapter implements IStandardIdentityProviderAdapter {
         }
     }
 
+    @Override
+    public void updateGroup(Map<String, Object> params) {
+        log.info("Starting Group's renaming!");
+
+        var accessToken = (String) params.get(ACCESS_TOKEN_MAP_KEY);
+        var groupId = (String) params.get(USER_GROUP_ID_MAP_KEY);
+        var groupName = (String) params.get(USER_GROUP_NAME_MAP_KEY);
+        var realm = getRealmFromToken(accessToken);
+
+        try (Keycloak keycloak = getKeycloakInstance(realm, accessToken)) {
+            GroupResource groupResource = keycloak.realm(realm).groups().group(groupId);
+            GroupRepresentation groupRepresentation = groupResource.toRepresentation();
+            groupRepresentation.setName(groupName);
+
+            groupResource.update(groupRepresentation);
+
+            log.info("Group successfully renamed within realm {}!", realm);
+        } catch (AdapterException e) {
+            log.error(e.getMessage());
+            throw new AdapterException(e.getMessage());
+        } catch (Exception e) {
+            var errorMessage = "Something went wrong while renaming a Group in Keycloak realm.";
+            log.error(errorMessage, e);
+            throw new AdapterException(errorMessage);
+        }
+    }
+
     public static Map<String, Object> buildParamsForUsersSearch(String accessToken, IDPUserSearchRequestFilter requestFilter,
                                                                 int firstResult, int maxResults) {
         Map<String, Object> params = new HashMap<>();

--- a/backend/src/main/java/io/littlehorse/usertasks/models/requests/UpdateGroupRequest.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/models/requests/UpdateGroupRequest.java
@@ -1,0 +1,14 @@
+package io.littlehorse.usertasks.models.requests;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateGroupRequest {
+    @NotBlank
+    private String name;
+}

--- a/backend/src/main/java/io/littlehorse/usertasks/services/GroupManagementService.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/services/GroupManagementService.java
@@ -3,6 +3,7 @@ package io.littlehorse.usertasks.services;
 import io.littlehorse.usertasks.idp_adapters.IStandardIdentityProviderAdapter;
 import io.littlehorse.usertasks.models.common.UserGroupDTO;
 import io.littlehorse.usertasks.models.requests.CreateGroupRequest;
+import io.littlehorse.usertasks.models.requests.UpdateGroupRequest;
 import io.littlehorse.usertasks.models.responses.IDPGroupDTO;
 import jakarta.validation.ValidationException;
 import lombok.NonNull;
@@ -33,7 +34,7 @@ public class GroupManagementService {
     }
 
     public Set<IDPGroupDTO> getGroups(@NonNull String accessToken, @Nullable String name, int firstResult, int maxResults,
-                                      @NonNull IStandardIdentityProviderAdapter identityProviderHandler) {
+                                      @NonNull IStandardIdentityProviderAdapter identityProviderAdapter) {
         Map<String, Object> params = new HashMap<>();
 
         params.put(ACCESS_TOKEN_MAP_KEY, accessToken);
@@ -43,6 +44,22 @@ public class GroupManagementService {
 
         params.entrySet().removeIf(entry -> Objects.isNull(entry.getValue()));
 
-        return identityProviderHandler.getGroups(params);
+        return identityProviderAdapter.getGroups(params);
+    }
+
+    public void updateGroup(@NonNull String accessToken, @NonNull String groupId, @NonNull UpdateGroupRequest request,
+                            @NonNull IStandardIdentityProviderAdapter identityProviderAdapter) {
+
+        Map<String, Object> lookupParams = Map.of(ACCESS_TOKEN_MAP_KEY, accessToken, USER_GROUP_NAME_MAP_KEY, request.getName());
+        UserGroupDTO foundGroup = identityProviderAdapter.getUserGroup(lookupParams);
+
+        if (Objects.nonNull(foundGroup)) {
+            throw new ValidationException("Group already exists with the requested name!");
+        }
+
+        Map<String, Object> updateParams = Map.of(ACCESS_TOKEN_MAP_KEY, accessToken, USER_GROUP_ID_MAP_KEY, groupId,
+                USER_GROUP_NAME_MAP_KEY, request.getName());
+
+        identityProviderAdapter.updateGroup(updateParams);
     }
 }


### PR DESCRIPTION
Injects UserTaskService to GroupManagementController in order to apply UserTaskRuns' assignment validations.
Adds respective OpenAPI Spec docs.
Adds UpdateGroupRequest to properly map request body used to update groups.
Implements a method in KeycloakAdapter to update a group's name through Keycloak's Admin API.
Adds respective unit tests.