### PR TITLE
feat(groups-management): adds DELETE endpoint to remove groups from IdP

### DIFF
--- a/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/IStandardIdentityProviderAdapter.java
@@ -50,4 +50,6 @@ public interface IStandardIdentityProviderAdapter {
     Set<IDPGroupDTO> getGroups(Map<String, Object> params);
 
     void updateGroup(Map<String, Object> params);
+
+    void deleteGroup(Map<String, Object> params);
 }

--- a/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/keycloak/KeycloakAdapter.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/idp_adapters/keycloak/KeycloakAdapter.java
@@ -636,6 +636,28 @@ public class KeycloakAdapter implements IStandardIdentityProviderAdapter {
         }
     }
 
+    @Override
+    public void deleteGroup(Map<String, Object> params) {
+        log.debug("Starting Group's deletion!");
+
+        var accessToken = (String) params.get(ACCESS_TOKEN_MAP_KEY);
+        var groupId = (String) params.get(USER_GROUP_ID_MAP_KEY);
+        var realm = getRealmFromToken(accessToken);
+
+        try (Keycloak keycloak = getKeycloakInstance(realm, accessToken)) {
+            keycloak.realm(realm).groups().group(groupId).remove();
+
+            log.debug("Group successfully deleted within realm {}!", realm);
+        } catch (AdapterException e) {
+            log.error(e.getMessage());
+            throw new AdapterException(e.getMessage());
+        } catch (Exception e) {
+            var errorMessage = "Something went wrong while deleting a Group in Keycloak realm.";
+            log.error(errorMessage, e);
+            throw new AdapterException(errorMessage);
+        }
+    }
+
     public static Map<String, Object> buildParamsForUsersSearch(String accessToken, IDPUserSearchRequestFilter requestFilter,
                                                                 int firstResult, int maxResults) {
         Map<String, Object> params = new HashMap<>();

--- a/backend/src/main/java/io/littlehorse/usertasks/services/GroupManagementService.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/services/GroupManagementService.java
@@ -49,7 +49,6 @@ public class GroupManagementService {
 
     public void updateGroup(@NonNull String accessToken, @NonNull String groupId, @NonNull UpdateGroupRequest request,
                             @NonNull IStandardIdentityProviderAdapter identityProviderAdapter) {
-
         Map<String, Object> lookupParams = Map.of(ACCESS_TOKEN_MAP_KEY, accessToken, USER_GROUP_NAME_MAP_KEY, request.getName());
         UserGroupDTO foundGroup = identityProviderAdapter.getUserGroup(lookupParams);
 
@@ -61,5 +60,12 @@ public class GroupManagementService {
                 USER_GROUP_NAME_MAP_KEY, request.getName());
 
         identityProviderAdapter.updateGroup(updateParams);
+    }
+
+    public void deleteGroup(@NonNull String accessToken, @NonNull String groupId,
+                            @NonNull IStandardIdentityProviderAdapter identityProviderAdapter) {
+        Map<String, Object> params = Map.of(ACCESS_TOKEN_MAP_KEY, accessToken, USER_GROUP_ID_MAP_KEY, groupId);
+
+        identityProviderAdapter.deleteGroup(params);
     }
 }

--- a/backend/src/test/java/io/littlehorse/usertasks/idp_adapters/keycloak/KeycloakAdapterTest.java
+++ b/backend/src/test/java/io/littlehorse/usertasks/idp_adapters/keycloak/KeycloakAdapterTest.java
@@ -3230,6 +3230,67 @@ class KeycloakAdapterTest {
         }
     }
 
+    @Test
+    void deleteGroup_shouldThrowAdapterExceptionCreatingKeycloakInstanceWhenRuntimeExceptionIsThrownGettingNewInstance() {
+        String groupId = UUID.randomUUID().toString();
+        Map<String, Object> params = Map.of(ACCESS_TOKEN_MAP_KEY, STUBBED_ACCESS_TOKEN, USER_GROUP_ID_MAP_KEY, groupId);
+
+        try (MockedStatic<Keycloak> ignored = mockStatic(Keycloak.class)) {
+            when(Keycloak.getInstance(anyString(), anyString(), anyString(), anyString()))
+                    .thenThrow(new RuntimeException("Error"));
+
+            AdapterException thrownException = assertThrows(AdapterException.class,
+                    () -> keycloakAdapter.deleteGroup(params));
+
+            var expectedErrorMessage = "Something went wrong while creating Keycloak instance.";
+
+            assertEquals(expectedErrorMessage, thrownException.getMessage());
+        }
+    }
+
+    @Test
+    void deleteGroup_shouldThrowExceptionCreatingKeycloakInstanceWhenAccessingRealms() {
+        String groupId = UUID.randomUUID().toString();
+        Map<String, Object> params = Map.of(ACCESS_TOKEN_MAP_KEY, STUBBED_ACCESS_TOKEN, USER_GROUP_ID_MAP_KEY, groupId);
+
+        try (MockedStatic<Keycloak> mockStaticKeycloak = mockStatic(Keycloak.class)) {
+            Keycloak mockKeycloakInstance = mock(Keycloak.class);
+            mockStaticKeycloak.when(() -> Keycloak.getInstance(anyString(), anyString(), anyString(), anyString()))
+                    .thenReturn(mockKeycloakInstance);
+            when(mockKeycloakInstance.realm(anyString())).thenThrow(new RuntimeException());
+
+            AdapterException thrownException = assertThrows(AdapterException.class,
+                    () -> keycloakAdapter.deleteGroup(params));
+
+            var expectedErrorMessage = "Something went wrong while deleting a Group in Keycloak realm.";
+
+            assertEquals(expectedErrorMessage, thrownException.getMessage());
+        }
+    }
+
+    @Test
+    void deleteGroup_shouldSucceedWhenNoExceptionsAreThrown() {
+        String groupId = UUID.randomUUID().toString();
+        Map<String, Object> params = Map.of(ACCESS_TOKEN_MAP_KEY, STUBBED_ACCESS_TOKEN, USER_GROUP_ID_MAP_KEY, groupId);
+
+        try (MockedStatic<Keycloak> mockStaticKeycloak = mockStatic(Keycloak.class)) {
+            Keycloak mockKeycloakInstance = mock(Keycloak.class);
+            RealmResource fakeRealmResource = mock(RealmResource.class);
+            GroupsResource fakeGroupsResource = mock(GroupsResource.class);
+            GroupResource fakeGroupResource = mock(GroupResource.class);
+
+            mockStaticKeycloak.when(() -> Keycloak.getInstance(anyString(), anyString(), anyString(), anyString()))
+                    .thenReturn(mockKeycloakInstance);
+            when(mockKeycloakInstance.realm(anyString())).thenReturn(fakeRealmResource);
+            when(fakeRealmResource.groups()).thenReturn(fakeGroupsResource);
+            when(fakeGroupsResource.group(eq(groupId))).thenReturn(fakeGroupResource);
+
+            keycloakAdapter.deleteGroup(params);
+
+            verify(fakeGroupResource).remove();
+        }
+    }
+
     private UserRepresentation getFakeUserRepresentation(String username) {
         UserRepresentation userRepresentation = new UserRepresentation();
         userRepresentation.setId(UUID.randomUUID().toString());

--- a/backend/src/test/java/io/littlehorse/usertasks/services/GroupManagementServiceTest.java
+++ b/backend/src/test/java/io/littlehorse/usertasks/services/GroupManagementServiceTest.java
@@ -285,4 +285,39 @@ class GroupManagementServiceTest {
         assertTrue(StringUtils.equalsIgnoreCase(groupIdBeingUpdated, (String) paramsSentToUpdate.get("userGroupId")));
         assertTrue(StringUtils.equalsIgnoreCase(groupName, (String) paramsSentToUpdate.get("userGroupName")));
     }
+
+    @Test
+    void deleteGroup_shouldThrowNullPointerExceptionWhenNullAccessTokenIsReceived() {
+        assertThrows(NullPointerException.class,
+                ()-> groupManagementService.deleteGroup(null, UUID.randomUUID().toString(), keycloakAdapter));
+    }
+
+    @Test
+    void deleteGroup_shouldThrowNullPointerExceptionWhenNullGroupIdIsReceived() {
+        assertThrows(NullPointerException.class,
+                ()-> groupManagementService.deleteGroup(fakeAccessToken, null, keycloakAdapter));
+    }
+
+    @Test
+    void deleteGroup_shouldThrowNullPointerExceptionWhenNullIdentityProviderAdapterIsReceived() {
+        assertThrows(NullPointerException.class,
+                ()-> groupManagementService.deleteGroup(fakeAccessToken, UUID.randomUUID().toString(), null));
+    }
+
+    @Test
+    void deleteGroup_shouldSucceedWhenNoExceptionsAreThrown() {
+        String fakeGroupId = UUID.randomUUID().toString();
+        groupManagementService.deleteGroup(fakeAccessToken, fakeGroupId, keycloakAdapter);
+
+        ArgumentCaptor<Map<String, Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+
+        verify(keycloakAdapter).deleteGroup(argumentCaptor.capture());
+
+        Map<String, Object> paramsSent = argumentCaptor.getValue();
+
+        int expectedParamsCount = 2;
+
+        assertEquals(expectedParamsCount, paramsSent.size());
+        assertTrue(StringUtils.equalsIgnoreCase(fakeGroupId, (String) paramsSent.get("userGroupId")));
+    }
 }


### PR DESCRIPTION
Adds respective OpenAPI Spec docs.
Implements a method in KeycloakAdapter to remove a group through Keycloak's Admin API.
Adds respective unit tests.