### PR TITLE
chore(users-management): assigns the view-users role after creating user in Keycloak

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,6 @@ configured Identity Provider.
 - IMPORTANT: These endpoints will **_only work with Keycloak_** as Identity Provider, for there's only one IdP adapter currently implemented.
 - These endpoints are set to only allow Admin users to hit them
 - In order to properly manage users, besides having the `lh-user-tasks-admin` role that identifies Users as Admins,
-they also need to have the `manage-users` and `view-realm` roles assigned.
+they also need to have the `manage-users`, `view-clients` and `view-realm` roles assigned.
 
 **In case that all Admin users were deleted, you will need to create at least 1 by using your Identity Provider's dashboard.**

--- a/backend/src/test/java/io/littlehorse/usertasks/idp_adapters/keycloak/KeycloakAdapterTest.java
+++ b/backend/src/test/java/io/littlehorse/usertasks/idp_adapters/keycloak/KeycloakAdapterTest.java
@@ -1942,9 +1942,33 @@ class KeycloakAdapterTest {
     @Test
     void createManagedUser_shouldSucceedWhenCreatingManagedUserOnlyWithUsernameNoExceptionsAreThrownAndResponseIsCreated() {
         var fakeUsername = "someUsername";
+        var fakeClientRepresentationId = UUID.randomUUID().toString();
+        var fakeViewUsersRoleId = UUID.randomUUID().toString();
+        var fakeUserId = UUID.randomUUID().toString();
+
         Map<String, Object> params = Map.of(USERNAME_MAP_KEY, fakeUsername, ACCESS_TOKEN_MAP_KEY, STUBBED_ACCESS_TOKEN);
+
         RealmResource fakeRealmResource = mock(RealmResource.class);
         UsersResource fakeUsersResource = mock(UsersResource.class);
+        ClientsResource fakeClientsResource = mock(ClientsResource.class);
+        ClientResource fakeClientResource = mock(ClientResource.class);
+        RolesResource fakeRolesResource = mock(RolesResource.class);
+        RoleResource fakeRoleResource = mock(RoleResource.class);
+        UserResource fakeUserResource = mock(UserResource.class);
+        RoleMappingResource fakeRoleMappingResource = mock(RoleMappingResource.class);
+        RoleScopeResource fakeRoleScopeResource = mock(RoleScopeResource.class);
+
+        ClientRepresentation fakeClientRepresentation = new ClientRepresentation();
+        fakeClientRepresentation.setId(fakeClientRepresentationId);
+        fakeClientRepresentation.setClientId(REALM_MANAGEMENT_CLIENT_ID);
+
+        RoleRepresentation fakeRoleRepresentation = new RoleRepresentation();
+        fakeRoleRepresentation.setId(fakeViewUsersRoleId);
+
+        UserRepresentation fakeUserRepresentation = new UserRepresentation();
+        fakeUserRepresentation.setId(fakeUserId);
+        fakeUserRepresentation.setUsername(fakeUsername);
+
         Response fakeResponse = Response.created(URI.create("www.some-fake-uri.com"))
                 .status(HttpStatus.CREATED.value())
                 .build();
@@ -1956,8 +1980,21 @@ class KeycloakAdapterTest {
             when(mockKeycloakInstance.realm(anyString())).thenReturn(fakeRealmResource);
             when(fakeRealmResource.users()).thenReturn(fakeUsersResource);
             when(fakeUsersResource.create(any(UserRepresentation.class))).thenReturn(fakeResponse);
+            when(fakeRealmResource.clients()).thenReturn(fakeClientsResource);
+            when(fakeClientsResource.findByClientId(eq(REALM_MANAGEMENT_CLIENT_ID))).thenReturn(Collections.singletonList(fakeClientRepresentation));
+            when(fakeClientsResource.get(eq(fakeClientRepresentationId))).thenReturn(fakeClientResource);
+            when(fakeClientResource.roles()).thenReturn(fakeRolesResource);
+            when(fakeRolesResource.get(eq(VIEW_USERS_ROLE_NAME))).thenReturn(fakeRoleResource);
+            when(fakeRoleResource.toRepresentation()).thenReturn(fakeRoleRepresentation);
+            when(fakeUsersResource.searchByUsername(eq(fakeUsername), eq(true))).thenReturn(Collections.singletonList(fakeUserRepresentation));
+            when(fakeUsersResource.get(eq(fakeUserId))).thenReturn(fakeUserResource);
+            when(fakeUserResource.roles()).thenReturn(fakeRoleMappingResource);
+            when(fakeRoleMappingResource.clientLevel(eq(fakeClientRepresentationId))).thenReturn(fakeRoleScopeResource);
 
             assertDoesNotThrow(() -> keycloakAdapter.createManagedUser(params));
+
+            verify(fakeUsersResource).create(any(UserRepresentation.class));
+            verify(fakeRoleScopeResource).add(anyList());
         }
     }
 
@@ -1965,10 +2002,34 @@ class KeycloakAdapterTest {
     void createManagedUser_shouldSucceedWhenCreatingManagedUserOnlyWithUsernameAndEmailNoExceptionsAreThrownAndResponseIsCreated() {
         var fakeUsername = "someUsername";
         var fakeEmail = "somemail@somedomain.com";
+        var fakeClientRepresentationId = UUID.randomUUID().toString();
+        var fakeViewUsersRoleId = UUID.randomUUID().toString();
+        var fakeUserId = UUID.randomUUID().toString();
+
         Map<String, Object> params = Map.of(USERNAME_MAP_KEY, fakeUsername, EMAIL_MAP_KEY, fakeEmail,
                 ACCESS_TOKEN_MAP_KEY, STUBBED_ACCESS_TOKEN);
+
         RealmResource fakeRealmResource = mock(RealmResource.class);
         UsersResource fakeUsersResource = mock(UsersResource.class);
+        ClientsResource fakeClientsResource = mock(ClientsResource.class);
+        ClientResource fakeClientResource = mock(ClientResource.class);
+        RolesResource fakeRolesResource = mock(RolesResource.class);
+        RoleResource fakeRoleResource = mock(RoleResource.class);
+        UserResource fakeUserResource = mock(UserResource.class);
+        RoleMappingResource fakeRoleMappingResource = mock(RoleMappingResource.class);
+        RoleScopeResource fakeRoleScopeResource = mock(RoleScopeResource.class);
+
+        ClientRepresentation fakeClientRepresentation = new ClientRepresentation();
+        fakeClientRepresentation.setId(fakeClientRepresentationId);
+        fakeClientRepresentation.setClientId(REALM_MANAGEMENT_CLIENT_ID);
+
+        RoleRepresentation fakeRoleRepresentation = new RoleRepresentation();
+        fakeRoleRepresentation.setId(fakeViewUsersRoleId);
+
+        UserRepresentation fakeUserRepresentation = new UserRepresentation();
+        fakeUserRepresentation.setId(fakeUserId);
+        fakeUserRepresentation.setUsername(fakeUsername);
+
         Response fakeResponse = Response.created(URI.create("www.some-fake-uri.com"))
                 .status(HttpStatus.CREATED.value())
                 .build();
@@ -1980,8 +2041,21 @@ class KeycloakAdapterTest {
             when(mockKeycloakInstance.realm(anyString())).thenReturn(fakeRealmResource);
             when(fakeRealmResource.users()).thenReturn(fakeUsersResource);
             when(fakeUsersResource.create(any(UserRepresentation.class))).thenReturn(fakeResponse);
+            when(fakeRealmResource.clients()).thenReturn(fakeClientsResource);
+            when(fakeClientsResource.findByClientId(eq(REALM_MANAGEMENT_CLIENT_ID))).thenReturn(Collections.singletonList(fakeClientRepresentation));
+            when(fakeClientsResource.get(eq(fakeClientRepresentationId))).thenReturn(fakeClientResource);
+            when(fakeClientResource.roles()).thenReturn(fakeRolesResource);
+            when(fakeRolesResource.get(eq(VIEW_USERS_ROLE_NAME))).thenReturn(fakeRoleResource);
+            when(fakeRoleResource.toRepresentation()).thenReturn(fakeRoleRepresentation);
+            when(fakeUsersResource.searchByUsername(eq(fakeUsername), eq(true))).thenReturn(Collections.singletonList(fakeUserRepresentation));
+            when(fakeUsersResource.get(eq(fakeUserId))).thenReturn(fakeUserResource);
+            when(fakeUserResource.roles()).thenReturn(fakeRoleMappingResource);
+            when(fakeRoleMappingResource.clientLevel(eq(fakeClientRepresentationId))).thenReturn(fakeRoleScopeResource);
 
             assertDoesNotThrow(() -> keycloakAdapter.createManagedUser(params));
+
+            verify(fakeUsersResource).create(any(UserRepresentation.class));
+            verify(fakeRoleScopeResource).add(anyList());
         }
     }
 
@@ -1991,10 +2065,34 @@ class KeycloakAdapterTest {
         var fakeEmail = "somemail@somedomain.com";
         var firstName = "Name";
         var lastName = "LastName";
+        var fakeClientRepresentationId = UUID.randomUUID().toString();
+        var fakeViewUsersRoleId = UUID.randomUUID().toString();
+        var fakeUserId = UUID.randomUUID().toString();
+
         Map<String, Object> params = Map.of(USERNAME_MAP_KEY, fakeUsername, EMAIL_MAP_KEY, fakeEmail,
                 FIRST_NAME_MAP_KEY, firstName, LAST_NAME_MAP_KEY, lastName, ACCESS_TOKEN_MAP_KEY, STUBBED_ACCESS_TOKEN);
+
         RealmResource fakeRealmResource = mock(RealmResource.class);
         UsersResource fakeUsersResource = mock(UsersResource.class);
+        ClientsResource fakeClientsResource = mock(ClientsResource.class);
+        ClientResource fakeClientResource = mock(ClientResource.class);
+        RolesResource fakeRolesResource = mock(RolesResource.class);
+        RoleResource fakeRoleResource = mock(RoleResource.class);
+        UserResource fakeUserResource = mock(UserResource.class);
+        RoleMappingResource fakeRoleMappingResource = mock(RoleMappingResource.class);
+        RoleScopeResource fakeRoleScopeResource = mock(RoleScopeResource.class);
+
+        ClientRepresentation fakeClientRepresentation = new ClientRepresentation();
+        fakeClientRepresentation.setId(fakeClientRepresentationId);
+        fakeClientRepresentation.setClientId(REALM_MANAGEMENT_CLIENT_ID);
+
+        RoleRepresentation fakeRoleRepresentation = new RoleRepresentation();
+        fakeRoleRepresentation.setId(fakeViewUsersRoleId);
+
+        UserRepresentation fakeUserRepresentation = new UserRepresentation();
+        fakeUserRepresentation.setId(fakeUserId);
+        fakeUserRepresentation.setUsername(fakeUsername);
+
         Response fakeResponse = Response.created(URI.create("www.some-fake-uri.com"))
                 .status(HttpStatus.CREATED.value())
                 .build();
@@ -2006,8 +2104,21 @@ class KeycloakAdapterTest {
             when(mockKeycloakInstance.realm(anyString())).thenReturn(fakeRealmResource);
             when(fakeRealmResource.users()).thenReturn(fakeUsersResource);
             when(fakeUsersResource.create(any(UserRepresentation.class))).thenReturn(fakeResponse);
+            when(fakeRealmResource.clients()).thenReturn(fakeClientsResource);
+            when(fakeClientsResource.findByClientId(eq(REALM_MANAGEMENT_CLIENT_ID))).thenReturn(Collections.singletonList(fakeClientRepresentation));
+            when(fakeClientsResource.get(eq(fakeClientRepresentationId))).thenReturn(fakeClientResource);
+            when(fakeClientResource.roles()).thenReturn(fakeRolesResource);
+            when(fakeRolesResource.get(eq(VIEW_USERS_ROLE_NAME))).thenReturn(fakeRoleResource);
+            when(fakeRoleResource.toRepresentation()).thenReturn(fakeRoleRepresentation);
+            when(fakeUsersResource.searchByUsername(eq(fakeUsername), eq(true))).thenReturn(Collections.singletonList(fakeUserRepresentation));
+            when(fakeUsersResource.get(eq(fakeUserId))).thenReturn(fakeUserResource);
+            when(fakeUserResource.roles()).thenReturn(fakeRoleMappingResource);
+            when(fakeRoleMappingResource.clientLevel(eq(fakeClientRepresentationId))).thenReturn(fakeRoleScopeResource);
 
             assertDoesNotThrow(() -> keycloakAdapter.createManagedUser(params));
+
+            verify(fakeUsersResource).create(any(UserRepresentation.class));
+            verify(fakeRoleScopeResource).add(anyList());
         }
     }
 

--- a/local-dev/keycloak-configurer/configure-keycloak.sh
+++ b/local-dev/keycloak-configurer/configure-keycloak.sh
@@ -153,6 +153,7 @@ configure_keycloak() {
    USER_TASKS_BRIDGE_ADMIN_ROLE_ID=$(http --ignore-stdin -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/roles/lh-user-tasks-admin" | jq -r ".id")
    MANAGE_USERS_ROLE_ID=$(http --ignore-stdin -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/clients/${REALM_MANAGEMENT_CLIENT_ID}/roles/manage-users" | jq -r ".id")
    VIEW_REALM_ROLE_ID=$(http --ignore-stdin -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/clients/${REALM_MANAGEMENT_CLIENT_ID}/roles/view-realm" | jq -r ".id")
+   VIEW_CLIENTS_ROLE_ID=$(http --ignore-stdin -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/clients/${REALM_MANAGEMENT_CLIENT_ID}/roles/view-clients" | jq -r ".id")
 
 #  Here we assign the view-users role to the nonAdmin user, and subsequently to the admin user as well. The view-users role
 #  allows users to see their userInfo details.
@@ -178,10 +179,16 @@ configure_keycloak() {
               [0][name]="manage-users"
 
 # The view-realm role allows admin users to see resources such as roles from a Keycloak realm
-   echo "Assigning manage-users Role to Admin User"
+   echo "Assigning view-realm Role to Admin User"
    http --ignore-stdin -b -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" POST "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/users/${ADMIN_USER_ID}/role-mappings/clients/${REALM_MANAGEMENT_CLIENT_ID}" \
               [0][id]="$VIEW_REALM_ROLE_ID" \
               [0][name]="view-realm"
+
+# The view-clients role allows admin users to see resources within a Keycloak client from a Keycloak realm
+   echo "Assigning view-clients Role to Admin User"
+   http --ignore-stdin -b -A bearer -a "${KEYCLOAK_ADMIN_ACCESS_TOKEN}" POST "${KEYCLOAK_URL}/admin/realms/${REALM_NAME}/users/${ADMIN_USER_ID}/role-mappings/clients/${REALM_MANAGEMENT_CLIENT_ID}" \
+              [0][id]="$VIEW_CLIENTS_ROLE_ID" \
+              [0][name]="view-clients"
 
    echo "Roles successfully assigned to users!"
 


### PR DESCRIPTION
Implements a private method in KeycloakAdapter to assign view-users role through Keycloak's Admin API.
Adds and modifies respective unit tests.
Assigns view-clients role to Admin user in configure-keycloak.sh.
Updates README.

This PR closes #119.