### PR TITLE
fix: matches GET config endpoint with publicly accessible path

### DIFF
--- a/backend/src/main/java/io/littlehorse/usertasks/configurations/WebSecurityConfiguration.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/configurations/WebSecurityConfiguration.java
@@ -79,10 +79,6 @@ public class WebSecurityConfiguration {
     public Map<String, LittleHorseGrpc.LittleHorseBlockingStub> lhClient(IdentityProviderConfigProperties identityProviderConfigProperties) {
         Set<String> configuredTenants = getConfiguredTenants(identityProviderConfigProperties);
 
-        if (CollectionUtils.isEmpty(configuredTenants)) {
-            throw new SecurityException("No Tenants found in configuration properties.");
-        }
-
         return getPerTenantLHClients(configuredTenants);
     }
 

--- a/backend/src/main/java/io/littlehorse/usertasks/controllers/PublicController.java
+++ b/backend/src/main/java/io/littlehorse/usertasks/controllers/PublicController.java
@@ -52,7 +52,7 @@ public class PublicController {
                             schema = @Schema(implementation = ProblemDetail.class))}
             )
     })
-    @GetMapping("/{tenant_id}/config")
+    @GetMapping("/config/{tenant_id}")
     public ResponseEntity<IdentityProviderListDTO> getIdentityProviderConfig(@PathVariable(name = "tenant_id") String tenantId) {
         log.atInfo()
                 .setMessage("Fetching IdP configurations for tenant: {}")


### PR DESCRIPTION
Removes validation that did not allow empty OIDC configuration. This is particularly useful given the fact that we want to have freedom to deploy UTB Backend with empty OIDC config, and later on add respective configs.